### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 **mcp-openapi-proxy** is a Python package implementing a Model Context Protocol (MCP) server that dynamically exposes REST APIs defined by OpenAPI specifications as MCP tools. This allows you to easily integrate any OpenAPI-described API into MCP-based workflows.
 
+<a href="https://glama.ai/mcp/servers/uxugly3ixf"><img width="380" height="200" src="https://glama.ai/mcp/servers/uxugly3ixf/badge" alt="mcp-any-openapi MCP server" /></a>
+
 ## Overview
 
 The package supports two operation modes:


### PR DESCRIPTION
This PR adds a badge for the [mcp-any-openapi](https://glama.ai/mcp/servers/uxugly3ixf) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/uxugly3ixf"><img width="380" height="200" src="https://glama.ai/mcp/servers/uxugly3ixf/badge" alt="mcp-any-openapi MCP server" /></a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.