### PR TITLE
Improve `normalize_tool_name`

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Refer to the **Examples** section below for practical configurations tailored to
 - `DEBUG`: (Optional) Enables verbose debug logging when set to "true", "1", or "yes".
 - `EXTRA_HEADERS`: (Optional) Additional HTTP headers in "Header: Value" format (one per line) to attach to outgoing API requests.
 - `SERVER_URL_OVERRIDE`: (Optional) Overrides the base URL from the OpenAPI specification when set, useful for custom deployments.
+- `TOOL_NAME_MAX_LENGTH`: (Optional) Truncates tool names to a max length.
 - **Additional Variable:** `OPENAPI_SPEC_URL_<hash>` – a variant for unique per-test configurations (falls back to `OPENAPI_SPEC_URL`).
 
 ## Examples

--- a/mcp_openapi_proxy/__init__.py
+++ b/mcp_openapi_proxy/__init__.py
@@ -6,6 +6,7 @@ FastMCP Server (static tools) based on OPENAPI_SIMPLE_MODE env var.
 """
 
 import os
+import sys
 from dotenv import load_dotenv
 from mcp_openapi_proxy.utils import setup_logging
 

--- a/mcp_openapi_proxy/utils.py
+++ b/mcp_openapi_proxy/utils.py
@@ -9,10 +9,12 @@ import logging
 import requests
 import yaml
 import jmespath
+import re
 from typing import Dict, Optional, Tuple
 from mcp import types
 
 logger = None
+
 
 def setup_logging(debug: bool = False) -> logging.Logger:
     """Set up logging with the specified debug level."""
@@ -27,36 +29,85 @@ def setup_logging(debug: bool = False) -> logging.Logger:
     logger.debug("Logging initialized, all output to stderr")
     return logger
 
+
 def normalize_tool_name(raw_name: str) -> str:
-    """Convert an HTTP method and path into a normalized tool name."""
+    """
+    Convert an HTTP method and path into a normalized tool name.
+    Drops common uninformative path parts like 'api' or 'v2'.
+
+    Examples:
+      "GET /users/{id}" -> "get_users_by_id"
+      "GET /api/users/{id}" -> "get_users_by_id"
+      "POST /api/v2/items/categories/{category}/tags/{tag}" -> "post_items_categories_by_category_tags_by_tag"
+    """
     try:
         method, path = raw_name.split(" ", 1)
         method = method.lower()
-        # Take only the last meaningful part, skip prefixes like /api/v*
-        path_parts = [part for part in path.split("/") if part and not part.startswith("{")]
+
+        # Filter out empty parts
+        path_parts = [part for part in path.split("/") if part]
         if not path_parts:
             return "unknown_tool"
-        last_part = path_parts[-1].lower()  # Force lowercase
-        name = f"{method}_{last_part}"
-        if "{" in path:
-            name += "_id"
+
+        # Common uninformative path parts to exclude
+        excluded_parts = ["api", "rest", "public"]
+
+        # Process each path part
+        normalized_parts = []
+
+        for part in path_parts:
+            # Skip common uninformative path parts
+            if part.lower() in excluded_parts:
+                continue
+
+            if "{" not in part:
+                normalized_parts.append(part.lower())
+                continue
+
+            # Extract all parameters from this path part
+            params = re.findall(r"\{([^}]+)\}", part)
+            if not params:
+                normalized_parts.append(part.lower())
+                continue
+
+            # Clean the part by removing parameters
+            clean_part = re.sub(r"\{[^}]+\}", "", part)
+
+            # If part only has parameters (or just separators)
+            if not clean_part or clean_part in [".", "-", "_"]:
+                normalized_parts.append(f"by_{'_'.join(params)}")
+            else:
+                # Handle complex parts with both text and parameters
+                # Strip any extra separators to avoid double underscores
+                base_part = (
+                    re.sub(r"[\.\-_]*\{[^}]+\}[\.\-_]*", "", part).lower().strip(".-_")
+                )
+                normalized_parts.append(f"{base_part}_by_{'_'.join(params)}")
+
+        name = f"{method}_{'_'.join(normalized_parts)}"
         return name if name else "unknown_tool"
     except ValueError:
-        logger.debug(f"Failed to normalize tool name: {raw_name}")
+        if logger:
+            logger.debug(f"Failed to normalize tool name: {raw_name}")
         return "unknown_tool"
+
 
 def is_tool_whitelist_set() -> bool:
     """Check if TOOL_WHITELIST environment variable is set."""
     return bool(os.getenv("TOOL_WHITELIST"))
 
+
 def is_tool_whitelisted(endpoint: str) -> bool:
     """Check if an endpoint is allowed based on TOOL_WHITELIST."""
     whitelist = os.getenv("TOOL_WHITELIST")
-    logger.debug(f"Checking whitelist - endpoint: {endpoint}, TOOL_WHITELIST: {whitelist}")
+    logger.debug(
+        f"Checking whitelist - endpoint: {endpoint}, TOOL_WHITELIST: {whitelist}"
+    )
     if not whitelist:
         logger.debug("No TOOL_WHITELIST set, allowing all endpoints.")
         return True
     import re
+
     whitelist_entries = [entry.strip() for entry in whitelist.split(",")]
     for entry in whitelist_entries:
         if "{" in entry:
@@ -65,7 +116,9 @@ def is_tool_whitelisted(endpoint: str) -> bool:
             pattern = re.sub(r"\\\{[^\\\}]+\\\}", r"([^/]+)", pattern)
             pattern = "^" + pattern + "($|/.*)$"
             if re.match(pattern, endpoint):
-                logger.debug(f"Endpoint {endpoint} matches whitelist entry {entry} using regex {pattern}")
+                logger.debug(
+                    f"Endpoint {endpoint} matches whitelist entry {entry} using regex {pattern}"
+                )
                 return True
         else:
             if endpoint.startswith(entry):
@@ -73,6 +126,7 @@ def is_tool_whitelisted(endpoint: str) -> bool:
                 return True
     logger.debug(f"Endpoint {endpoint} not in whitelist - skipping.")
     return False
+
 
 def fetch_openapi_spec(url: str, retries: int = 3) -> Optional[Dict]:
     """Fetch and parse an OpenAPI specification from a URL with retries."""
@@ -96,16 +150,21 @@ def fetch_openapi_spec(url: str, retries: int = 3) -> Optional[Dict]:
                     spec = yaml.safe_load(content)
                     logger.debug(f"Parsed as YAML from {url}")
                 except yaml.YAMLError as ye:
-                    logger.error(f"YAML parsing failed: {ye}. Raw content: {content[:500]}...")
+                    logger.error(
+                        f"YAML parsing failed: {ye}. Raw content: {content[:500]}..."
+                    )
                     return None
             return spec
         except requests.RequestException as e:
             attempt += 1
             logger.warning(f"Fetch attempt {attempt}/{retries} failed: {e}")
             if attempt == retries:
-                logger.error(f"Failed to fetch spec from {url} after {retries} attempts: {e}")
+                logger.error(
+                    f"Failed to fetch spec from {url} after {retries} attempts: {e}"
+                )
                 return None
     return None
+
 
 def build_base_url(spec: Dict) -> Optional[str]:
     """Construct the base URL from the OpenAPI spec or override."""
@@ -123,12 +182,16 @@ def build_base_url(spec: Dict) -> Optional[str]:
     elif "host" in spec and "schemes" in spec:
         scheme = spec["schemes"][0] if spec["schemes"] else "https"
         return f"{scheme}://{spec['host']}{spec.get('basePath', '')}"
-    logger.error("No servers or host/schemes defined in spec and no SERVER_URL_OVERRIDE.")
+    logger.error(
+        "No servers or host/schemes defined in spec and no SERVER_URL_OVERRIDE."
+    )
     return None
+
 
 def get_tool_prefix() -> str:
     """Get the tool name prefix from TOOL_NAME_PREFIX environment variable."""
     return os.getenv("TOOL_NAME_PREFIX", "")
+
 
 def handle_auth(operation: Dict) -> Dict[str, str]:
     """Handle authentication based on environment variables and operation security."""
@@ -144,8 +207,11 @@ def handle_auth(operation: Dict) -> Dict[str, str]:
         elif auth_type == "api-key":
             key_name = os.getenv("API_AUTH_HEADER", "Authorization")
             headers[key_name] = api_key
-            logger.debug(f"Using API_KEY as API-Key in header {key_name}: {api_key[:5]}...")
+            logger.debug(
+                f"Using API_KEY as API-Key in header {key_name}: {api_key[:5]}..."
+            )
     return headers
+
 
 def strip_parameters(parameters: Dict) -> Dict:
     """Strip specified parameters from the input based on STRIP_PARAM."""
@@ -159,6 +225,7 @@ def strip_parameters(parameters: Dict) -> Dict:
     logger.debug(f"Parameters after stripping: {result}")
     return result
 
+
 def detect_response_type(response_text: str) -> Tuple[types.TextContent, str]:
     """Determine response type based on JSON validity.
     If response_text is valid JSON, return a wrapped JSON string;
@@ -167,9 +234,14 @@ def detect_response_type(response_text: str) -> Tuple[types.TextContent, str]:
     try:
         json.loads(response_text)
         wrapped_text = json.dumps({"text": response_text})
-        return types.TextContent(type="text", text=wrapped_text, id=None), "JSON response"
+        return types.TextContent(
+            type="text", text=wrapped_text, id=None
+        ), "JSON response"
     except json.JSONDecodeError:
-        return types.TextContent(type="text", text=response_text.strip(), id=None), "non-JSON text"
+        return types.TextContent(
+            type="text", text=response_text.strip(), id=None
+        ), "non-JSON text"
+
 
 def get_additional_headers() -> Dict[str, str]:
     """Parse additional headers from EXTRA_HEADERS environment variable."""

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -4,12 +4,53 @@ Unit tests for utility functions in mcp-openapi-proxy.
 
 import os
 import pytest
-from mcp_openapi_proxy.utils import normalize_tool_name, detect_response_type, build_base_url, handle_auth, strip_parameters
+from mcp_openapi_proxy.utils import (
+    normalize_tool_name,
+    detect_response_type,
+    build_base_url,
+    handle_auth,
+    strip_parameters,
+)
+
 
 def test_normalize_tool_name():
-    assert normalize_tool_name("GET /api/v2/users") == "get_users"
-    assert normalize_tool_name("POST /users/{id}") == "post_users_id"
+    assert normalize_tool_name("GET /api/v2/users") == "get_v2_users"
+    assert normalize_tool_name("POST /users/{id}") == "post_users_by_id"
+    assert (
+        normalize_tool_name("GET /api/agent/service/list") == "get_agent_service_list"
+    )
+    assert (
+        normalize_tool_name("GET /api/agent/announcement/list")
+        == "get_agent_announcement_list"
+    )
+    assert (
+        normalize_tool_name("GET /section/resources/{param1}.{param2}")
+        == "get_section_resources_by_param1_param2"
+    )
+    assert (
+        normalize_tool_name("GET /resource/{param1}/{param2}-{param3}")
+        == "get_resource_by_param1_by_param2_param3"
+    )
+    # Complex parameter patterns
+    assert normalize_tool_name("GET /{param1}/resources") == "get_by_param1_resources"
+    assert (
+        normalize_tool_name("GET /resources/{param1}-{param2}.{param3}")
+        == "get_resources_by_param1_param2_param3"
+    )
+    assert normalize_tool_name("GET /users/{id1}/{id2}") == "get_users_by_id1_by_id2"
+    # Special characters in paths
+    assert (
+        normalize_tool_name("GET /search+filter/results") == "get_search+filter_results"
+    )
+    assert (
+        normalize_tool_name("GET /user_profiles/active") == "get_user_profiles_active"
+    )
+    assert (
+        normalize_tool_name("GET /data@year=2023/summary")
+        == "get_data@year=2023_summary"
+    )
     assert normalize_tool_name("INVALID") == "unknown_tool"
+
 
 def test_detect_response_type_json():
     content, msg = detect_response_type('{"key": "value"}')
@@ -17,34 +58,41 @@ def test_detect_response_type_json():
     assert content.text == '{"text": "{\\"key\\": \\"value\\"}"}'
     assert "JSON" in msg
 
+
 def test_detect_response_type_text():
     content, msg = detect_response_type("plain text")
     assert content.type == "text"
     assert content.text == "plain text"
     assert "non-JSON" in msg
 
+
 def test_build_base_url_servers():
     spec = {"servers": [{"url": "https://api.example.com/v1"}]}
     assert build_base_url(spec) == "https://api.example.com/v1"
 
+
 def test_build_base_url_host():
     spec = {"host": "api.example.com", "schemes": ["https"], "basePath": "/v1"}
     assert build_base_url(spec) == "https://api.example.com/v1"
+
 
 def test_handle_auth_with_api_key(monkeypatch):
     monkeypatch.setenv("API_KEY", "testkey")
     headers = handle_auth({"method": "GET"})
     assert headers == {"Authorization": "Bearer testkey"}
 
+
 def test_handle_auth_no_api_key():
     headers = handle_auth({"method": "GET"})
     assert headers == {}
+
 
 def test_strip_parameters_with_param(monkeypatch):
     monkeypatch.setenv("STRIP_PARAM", "token")
     params = {"token": "abc123", "channel": "test"}
     result = strip_parameters(params)
     assert result == {"channel": "test"}
+
 
 def test_strip_parameters_no_param():
     params = {"channel": "test"}

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -2,8 +2,6 @@
 Unit tests for utility functions in mcp-openapi-proxy.
 """
 
-import os
-import pytest
 from mcp_openapi_proxy.utils import (
     normalize_tool_name,
     detect_response_type,
@@ -16,41 +14,17 @@ from mcp_openapi_proxy.utils import (
 def test_normalize_tool_name():
     assert normalize_tool_name("GET /api/v2/users") == "get_v2_users"
     assert normalize_tool_name("POST /users/{id}") == "post_users_by_id"
-    assert (
-        normalize_tool_name("GET /api/agent/service/list") == "get_agent_service_list"
-    )
-    assert (
-        normalize_tool_name("GET /api/agent/announcement/list")
-        == "get_agent_announcement_list"
-    )
-    assert (
-        normalize_tool_name("GET /section/resources/{param1}.{param2}")
-        == "get_section_resources_by_param1_param2"
-    )
-    assert (
-        normalize_tool_name("GET /resource/{param1}/{param2}-{param3}")
-        == "get_resource_by_param1_by_param2_param3"
-    )
-    # Complex parameter patterns
+    assert normalize_tool_name("GET /api/agent/service/list") == "get_agent_service_list"
+    assert normalize_tool_name("GET /api/agent/announcement/list") == "get_agent_announcement_list"
+    assert normalize_tool_name("GET /section/resources/{param1}.{param2}") == "get_section_resources_by_param1_param2"
+    assert normalize_tool_name("GET /resource/{param1}/{param2}-{param3}") == "get_resource_by_param1_by_param2_param3"
     assert normalize_tool_name("GET /{param1}/resources") == "get_by_param1_resources"
-    assert (
-        normalize_tool_name("GET /resources/{param1}-{param2}.{param3}")
-        == "get_resources_by_param1_param2_param3"
-    )
+    assert normalize_tool_name("GET /resources/{param1}-{param2}.{param3}") == "get_resources_by_param1_param2_param3"
     assert normalize_tool_name("GET /users/{id1}/{id2}") == "get_users_by_id1_by_id2"
-    # Special characters in paths
-    assert (
-        normalize_tool_name("GET /search+filter/results") == "get_search+filter_results"
-    )
-    assert (
-        normalize_tool_name("GET /user_profiles/active") == "get_user_profiles_active"
-    )
-    assert (
-        normalize_tool_name("GET /data@year=2023/summary")
-        == "get_data@year=2023_summary"
-    )
+    assert normalize_tool_name("GET /users/user_{id}") == "get_users_user_by_id"
+    assert normalize_tool_name("GET /search+filter/results") == "get_search+filter_results"
+    assert normalize_tool_name("GET /user_profiles/active") == "get_user_profiles_active"
     assert normalize_tool_name("INVALID") == "unknown_tool"
-
 
 def test_detect_response_type_json():
     content, msg = detect_response_type('{"key": "value"}')
@@ -58,41 +32,34 @@ def test_detect_response_type_json():
     assert content.text == '{"text": "{\\"key\\": \\"value\\"}"}'
     assert "JSON" in msg
 
-
 def test_detect_response_type_text():
     content, msg = detect_response_type("plain text")
     assert content.type == "text"
     assert content.text == "plain text"
     assert "non-JSON" in msg
 
-
 def test_build_base_url_servers():
     spec = {"servers": [{"url": "https://api.example.com/v1"}]}
     assert build_base_url(spec) == "https://api.example.com/v1"
 
-
 def test_build_base_url_host():
     spec = {"host": "api.example.com", "schemes": ["https"], "basePath": "/v1"}
     assert build_base_url(spec) == "https://api.example.com/v1"
-
 
 def test_handle_auth_with_api_key(monkeypatch):
     monkeypatch.setenv("API_KEY", "testkey")
     headers = handle_auth({"method": "GET"})
     assert headers == {"Authorization": "Bearer testkey"}
 
-
 def test_handle_auth_no_api_key():
     headers = handle_auth({"method": "GET"})
     assert headers == {}
-
 
 def test_strip_parameters_with_param(monkeypatch):
     monkeypatch.setenv("STRIP_PARAM", "token")
     params = {"token": "abc123", "channel": "test"}
     result = strip_parameters(params)
     assert result == {"channel": "test"}
-
 
 def test_strip_parameters_no_param():
     params = {"channel": "test"}

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -2,14 +2,7 @@
 Unit tests for utility functions in mcp-openapi-proxy.
 """
 
-from mcp_openapi_proxy.utils import (
-    normalize_tool_name,
-    detect_response_type,
-    build_base_url,
-    handle_auth,
-    strip_parameters,
-)
-
+from mcp_openapi_proxy.utils import normalize_tool_name, detect_response_type, build_base_url, handle_auth, strip_parameters
 
 def test_normalize_tool_name():
     assert normalize_tool_name("GET /api/v2/users") == "get_v2_users"


### PR DESCRIPTION
This PR makes some changes to `normalize_tool_name` to improve the uniqueness of tool names and better handle url templating.

This was originally motivated by the fact that there are real world examples where a url template is not the first item in a part of the url (as assumption currently in place). See the Hansard API for UK Parliament (https://hansard-api.parliament.uk/swagger/ui/index). Previously `normalize_tool_name` would fail to remove all path templates from the url.

Also, since I was here I also fixed the issue highlighted in #6 on path normalisation where two reasonably different URL paths could be assigned the same toolname.

Lastly, I introduced a new environment variable to limit the max tool name length. Somewhat strangely, tools such as 5ire https://5ire.app/ have a tool name limit of 64 characters.