### PR TITLE
fix(auth): support custom Authorization schemes via API_AUTH_TYPE (NetBox 'Token')

### DIFF
--- a/examples/netbox-claude_desktop_config.json
+++ b/examples/netbox-claude_desktop_config.json
@@ -2,11 +2,15 @@
   "mcpServers": {
     "netbox": {
       "command": "uvx",
-      "args": ["mcp-openapi-proxy"],
+      "args": [
+        "mcp-openapi-proxy"
+      ],
       "env": {
         "OPENAPI_SPEC_URL": "https://raw.githubusercontent.com/APIs-guru/openapi-directory/refs/heads/main/APIs/netbox.dev/3.4/openapi.yaml",
         "SERVER_URL_OVERRIDE": "http://localhost:8000/api",
-        "API_KEY": "${NETBOX_API_KEY}"
+        "API_KEY": "${NETBOX_API_KEY}",
+        "API_AUTH_TYPE": "Token",
+        "TOOL_WHITELIST": "/ipam/ip-addresses"
       }
     }
   }

--- a/mcp_openapi_proxy/utils.py
+++ b/mcp_openapi_proxy/utils.py
@@ -224,7 +224,8 @@ def handle_auth(operation: Dict) -> Dict[str, str]:
     """
     headers = {}
     api_key = os.getenv("API_KEY")
-    auth_type = os.getenv("API_AUTH_TYPE", "Bearer").lower()
+    auth_type_raw = os.getenv("API_AUTH_TYPE", "Bearer")
+    auth_type = auth_type_raw.lower()
     if api_key:
         if auth_type == "bearer":
             logger.debug(f"Using API_KEY as Bearer token.") # Avoid logging key prefix
@@ -236,8 +237,10 @@ def handle_auth(operation: Dict) -> Dict[str, str]:
             key_name = os.getenv("API_AUTH_HEADER", "Authorization")
             headers[key_name] = api_key
             logger.debug(f"Using API_KEY as API-Key in header '{key_name}'.") # Avoid logging key prefix
-        else:
-            logger.warning(f"Unsupported API_AUTH_TYPE: {auth_type}")
+        elif auth_type:
+            # Custom scheme prefix, e.g. API_AUTH_TYPE=Token for NetBox -> "Authorization: Token <key>"
+            headers["Authorization"] = f"{auth_type_raw} {api_key}"
+            logger.debug(f"Using API_KEY with custom auth scheme '{auth_type_raw}'.")
     # TODO: Add logic to check operation['security'] and spec['components']['securitySchemes']
     #       to potentially override or supplement env var based auth.
     return headers


### PR DESCRIPTION
Fixes #24

## Summary
- `API_AUTH_TYPE` previously only honored `bearer`/`basic`/`api-key`; any other value logged *Unsupported* and sent **no auth header**, so APIs with custom schemes (NetBox's `Authorization: Token <key>`) could never authenticate — including our own documented netbox example.
- Unknown auth types are now used as a custom scheme prefix: `API_AUTH_TYPE=Token` → `Authorization: Token <key>`. `bearer`/`basic`/`api-key` behavior is unchanged.
- netbox example config gains `API_AUTH_TYPE=Token` and `TOOL_WHITELIST=/ipam/ip-addresses` (the full netbox spec is enormous).

## Live verification
Against a local netbox-docker v4.2 via the MCP stdio bridge (initialize → tools/list → tools/call):
- 9 whitelisted IPAM tools discovered
- POST created two IP addresses (ids 1, 2)
- GET read both back through the bridge (count=1 each)

Before the fix the same flow returned *403 Forbidden* on every call while a direct `curl -H 'Authorization: Token …'` returned 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)