### PR TITLE
fix(examples): elevenlabs needs SERVER_URL_OVERRIDE + xi-api-key auth header

### DIFF
--- a/examples/elevenlabs-claude_desktop_config.json
+++ b/examples/elevenlabs-claude_desktop_config.json
@@ -2,10 +2,15 @@
   "mcpServers": {
     "elevenlabs": {
       "command": "uvx",
-      "args": ["mcp-openapi-proxy"],
+      "args": [
+        "mcp-openapi-proxy"
+      ],
       "env": {
         "OPENAPI_SPEC_URL": "https://raw.githubusercontent.com/APIs-guru/openapi-directory/refs/heads/main/APIs/elevenlabs.io/1.0/openapi.yaml",
-        "API_KEY": "${ELEVENLABS_API_KEY}"
+        "API_KEY": "${ELEVENLABS_API_KEY}",
+        "SERVER_URL_OVERRIDE": "https://api.elevenlabs.io",
+        "API_AUTH_TYPE": "api-key",
+        "API_AUTH_HEADER": "xi-api-key"
       }
     }
   }


### PR DESCRIPTION
Fixes #29

The ElevenLabs spec has no `servers` entry and authenticates via the `xi-api-key` header. Example config now sets `SERVER_URL_OVERRIDE=https://api.elevenlabs.io`, `API_AUTH_TYPE=api-key`, `API_AUTH_HEADER=xi-api-key`.

Live-verified 2026-06-12: 19 tools registered, `get_v1_user_subscription` returned real account data (free tier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)