### PR TITLE
fix(docs): update dead render spec URL (302 → /404) to current published spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Render offers infrastructure hosting that can be managed via an API. The provide
 Retrieve the Render OpenAPI specification:
 
 ```bash
-curl https://api-docs.render.com/openapi/6140fb3daeae351056086186
+curl https://api-docs.render.com/openapi/render-public-api-1.json
 ```
 
 Ensure the response is a valid OpenAPI document.
@@ -224,7 +224,7 @@ Add the following configuration to your MCP ecosystem settings:
             "command": "uvx",
             "args": ["mcp-openapi-proxy"],
             "env": {
-                "OPENAPI_SPEC_URL": "https://api-docs.render.com/openapi/6140fb3daeae351056086186",
+                "OPENAPI_SPEC_URL": "https://api-docs.render.com/openapi/render-public-api-1.json",
                 "TOOL_WHITELIST": "/services,/maintenance",
                 "API_KEY": "your_render_token_here"
             }
@@ -238,7 +238,7 @@ Add the following configuration to your MCP ecosystem settings:
 Launch the proxy with your Render configuration:
 
 ```bash
-OPENAPI_SPEC_URL="https://api-docs.render.com/openapi/6140fb3daeae351056086186" TOOL_WHITELIST="/services,/maintenance" API_KEY="your_render_token_here" uvx mcp-openapi-proxy
+OPENAPI_SPEC_URL="https://api-docs.render.com/openapi/render-public-api-1.json" TOOL_WHITELIST="/services,/maintenance" API_KEY="your_render_token_here" uvx mcp-openapi-proxy
 ```
 
 Then refer to the [JSON-RPC Testing](#json-rpc-testing) section for instructions on listing resources and tools.

--- a/examples/render-claude_desktop_config.json
+++ b/examples/render-claude_desktop_config.json
@@ -6,7 +6,7 @@
         "mcp-openapi-proxy"
       ],
       "env": {
-        "OPENAPI_SPEC_URL": "https://api-docs.render.com/openapi/6140fb3daeae351056086186",
+        "OPENAPI_SPEC_URL": "https://api-docs.render.com/openapi/render-public-api-1.json",
         "TOOL_WHITELIST": "/services,/maintenance",
         "API_KEY": "your_render_token_here"
       }


### PR DESCRIPTION
Fixes #26

`https://api-docs.render.com/openapi/6140fb3daeae351056086186` now redirects to ReadMe's /404. Replaced with `https://api-docs.render.com/openapi/render-public-api-1.json` in README + example config.

Live-verified 2026-06-12: 52 tools with the documented `TOOL_WHITELIST=/services,/maintenance`; `get_services` returned real data.

Note: PR #21 removes the render example on its branch — if #21 lands first this reduces to the README hunk; merge order is flexible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)