### PR TITLE
fix(whitelist): TOOL_WHITELIST prefixes now match Slack-style dot paths

### DIFF
--- a/mcp_openapi_proxy/utils.py
+++ b/mcp_openapi_proxy/utils.py
@@ -359,9 +359,12 @@ def is_tool_whitelisted(endpoint: str) -> bool:
                  logger.error(f"Invalid regex pattern generated from whitelist entry '{entry}': {pattern}. Error: {e}")
                  continue # Skip this invalid pattern
         elif normalized_endpoint.startswith(normalized_entry):
-             # Simple prefix match (e.g., /users allows /users/123)
-             # Ensure it matches either the exact path or a path segment start
-             if normalized_endpoint == normalized_entry or normalized_endpoint.startswith(normalized_entry + "/"):
+             # Simple prefix match (e.g., /users allows /users/123).
+             # A segment may continue with "/" (REST style) or "." (Slack-style
+             # method paths such as /users.list), but /chat must not match /chatter.
+             if (normalized_endpoint == normalized_entry
+                     or normalized_endpoint.startswith(normalized_entry + "/")
+                     or normalized_endpoint.startswith(normalized_entry + ".")):
                   logger.debug(f"Endpoint '{normalized_endpoint}' matches whitelist prefix '{normalized_entry}' from entry '{entry}'")
                   return True
 

--- a/tests/unit/test_utils_whitelist.py
+++ b/tests/unit/test_utils_whitelist.py
@@ -6,3 +6,25 @@ def test_is_tool_whitelisted_multiple(monkeypatch):
     assert is_tool_whitelisted("/bar/123")
     assert not is_tool_whitelisted("/baz/999")
     monkeypatch.delenv("TOOL_WHITELIST", raising=False)
+
+
+def test_is_tool_whitelisted_dot_paths(monkeypatch):
+    """Slack-style method paths: /users must match /users.list (issue #27)."""
+    from mcp_openapi_proxy.utils import is_tool_whitelisted
+    monkeypatch.setenv("TOOL_WHITELIST", "/chat,/users,/conversations")
+    assert is_tool_whitelisted("/users.list")
+    assert is_tool_whitelisted("/chat.postMessage")
+    assert is_tool_whitelisted("/conversations.history")
+    # prefix must stop at a delimiter: /chat must NOT match /chatter
+    assert not is_tool_whitelisted("/chatter")
+    assert not is_tool_whitelisted("/usersearch")
+    monkeypatch.delenv("TOOL_WHITELIST", raising=False)
+
+
+def test_is_tool_whitelisted_slash_still_works(monkeypatch):
+    from mcp_openapi_proxy.utils import is_tool_whitelisted
+    monkeypatch.setenv("TOOL_WHITELIST", "/ipam/ip-addresses")
+    assert is_tool_whitelisted("/ipam/ip-addresses")
+    assert is_tool_whitelisted("/ipam/ip-addresses/{id}")
+    assert not is_tool_whitelisted("/ipam/ip-ranges")
+    monkeypatch.delenv("TOOL_WHITELIST", raising=False)


### PR DESCRIPTION
Fixes #27

`is_tool_whitelisted()` prefix matching required the next character to be `/`, so Slack's dot-style method paths (`/users.list`, `/chat.postMessage`) never matched the documented `TOOL_WHITELIST=/chat,/users,...` — the slack example registered **0 tools** and the server shut down.

A whitelist segment may now continue with `/` **or** `.`; `/chat` still does not match `/chatter`.

- 2 new unit tests (dot-path matching + existing slash behavior); whitelist suites pass 8/8
- Live-verified against the Slack spec during the example-verification sweep (7 tools, `auth.test` ok)

🤖 Generated with [Claude Code](https://claude.com/claude-code)