### PR TITLE
README: collapse examples into <details>, add tested-client matrix + verification results

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,19 +12,9 @@
   - [FastMCP Mode (Simple Mode)](#fastmcp-mode-simple-mode)
   - [Low-Level Mode (Default)](#low-level-mode-default)
 - [Environment Variables](#environment-variables)
-- [Examples](#examples)
-  - [Glama Example](#glama-example)
-  - [Fly.io Example](#flyio-example)
-  - [Render Example](#render-example)
-  - [Slack Example](#slack-example)
-  - [GetZep Example](#getzep-example)
-  - [Virustotal Example](#virustotal-example)
-  - [Notion Example](#notion-example)
-  - [Asana Example](#asana-example)
-  - [APIs.guru Example](#apisguru-example)
-  - [NetBox Example](#netbox-example)
-  - [Box API Example](#box-api-example)
-  - [WolframAlpha API Example](#wolframalpha-api-example)
+- [Verified Clients & Live Results (2026-06-12)](#verified-clients--live-results-2026-06-12)
+  - [Tips](#tips)
+- [Examples](#examples) — Glama, Fly.io, Render, Slack, GetZep, Virustotal, Notion, Asana, APIs.guru, NetBox, Box, WolframAlpha (collapsed)
 - [Troubleshooting](#troubleshooting)
 - [License](#license)
 
@@ -106,11 +96,154 @@ Refer to the **Examples** section below for practical configurations tailored to
 - `IGNORE_SSL_SPEC`: (Optional) Set to `true` to disable SSL certificate verification when fetching the OpenAPI spec.
 - `IGNORE_SSL_TOOLS`: (Optional) Set to `true` to disable SSL certificate verification for API requests made by tools.
 
+## Verified Clients & Live Results (2026-06-12)
+
+The example configurations below were exercised against the live APIs, and the proxy was attached to a range of agent CLIs over stdio MCP. Results from that verification run:
+
+### API example results
+
+| API example | Tools | Sample call proven | Extra env needed |
+|---|---|---|---|
+| glama | 6 | `get_v1_attributes` | none |
+| apis.guru | 7 | `get_metrics_json` | none |
+| wolframalpha | 2 | `get_v1_llm_api` | `API_KEY` |
+| virustotal | 4 | IP report | `API_KEY` + `API_AUTH_TYPE=api-key` + `API_AUTH_HEADER=x-apikey` |
+| asana | 73 (whitelist `/workspaces,/projects,/tasks`) | created project + 11 tasks | `SERVER_URL_OVERRIDE` + `API_KEY` |
+| render | 52 | `get_services` | `API_KEY` (NEW spec URL `render-public-api-1.json`) |
+| notion | 4–5 (whitelist `/v1/users,/v1/search` or `/v1/pages`) | page create + title read-back | `SERVER_URL_OVERRIDE` + `EXTRA_HEADERS` (`Notion-Version`) + `API_KEY` |
+| elevenlabs | 19 | TTS mp3 generated | `SERVER_URL_OVERRIDE` + `API_AUTH_TYPE=api-key` + `API_AUTH_HEADER=xi-api-key` |
+| flyio | 34–35 | apps + machine health | `API_KEY` |
+| slack | 7 (exact dot-path whitelist until #27 fix) | `auth.test` + `postMessage` | `API_KEY` |
+| netbox | 9 (whitelist `/ipam/ip-addresses`) | IPAM write + read | `API_KEY` + `API_AUTH_TYPE=Token` |
+
+### Client matrix
+
+| Agent CLI | MCP attach mechanism | Tool calls | Prompts/Resources surfaced to model? |
+|---|---|---|---|
+| Codex | `codex exec -c mcp_servers.*` | ✅ native | ❌ (used raw stdio) |
+| Gemini | project `.gemini/settings.json` `mcpServers` | ✅ native | ❌ interactive slash-commands only |
+| Qwen | project `.qwen/settings.json` | ✅ native | ❌ NO_PROMPT_ACCESS |
+| Kilocode | global `settings/mcp_settings.json`, clean workspace | ✅ native | ❌ |
+| opencode | `~/.config/opencode/opencode.json` `mcp` | ✅ native | ❌ |
+| Vibe | `~/.vibe/config.toml` `[[mcp_servers]]` | ✅ discovery + reads (writes flaky) | ❌ |
+| agy | — | ❌ headless cannot enable MCP | — |
+| letta cloud | — | ❌ stdio rejected (remote MCP only) | — |
+
+Minimal sanitized configs per client (the no-auth Glama spec is used as the smallest working example; substitute your own spec URL and `$YOUR_KEY` as needed):
+
+<details>
+<summary><b>Codex</b> — inline <code>-c mcp_servers.*</code> overrides</summary>
+
+```bash
+codex exec \
+  -c 'mcp_servers.glama.command="uvx"' \
+  -c 'mcp_servers.glama.args=["mcp-openapi-proxy"]' \
+  -c 'mcp_servers.glama.env.OPENAPI_SPEC_URL="https://glama.ai/api/mcp/openapi.json"' \
+  "list the available tools"
+```
+
+</details>
+
+<details>
+<summary><b>Gemini</b> — project <code>.gemini/settings.json</code></summary>
+
+```json
+{
+  "mcpServers": {
+    "glama": {
+      "command": "uvx",
+      "args": ["mcp-openapi-proxy"],
+      "env": { "OPENAPI_SPEC_URL": "https://glama.ai/api/mcp/openapi.json" }
+    }
+  }
+}
+```
+
+</details>
+
+<details>
+<summary><b>Qwen</b> — project <code>.qwen/settings.json</code></summary>
+
+```json
+{
+  "mcpServers": {
+    "glama": {
+      "command": "uvx",
+      "args": ["mcp-openapi-proxy"],
+      "env": { "OPENAPI_SPEC_URL": "https://glama.ai/api/mcp/openapi.json" }
+    }
+  }
+}
+```
+
+</details>
+
+<details>
+<summary><b>Kilocode</b> — global <code>settings/mcp_settings.json</code> (use a clean workspace)</summary>
+
+```json
+{
+  "mcpServers": {
+    "glama": {
+      "command": "uvx",
+      "args": ["mcp-openapi-proxy"],
+      "env": { "OPENAPI_SPEC_URL": "https://glama.ai/api/mcp/openapi.json" }
+    }
+  }
+}
+```
+
+</details>
+
+<details>
+<summary><b>opencode</b> — <code>~/.config/opencode/opencode.json</code> <code>mcp</code> block</summary>
+
+```json
+{
+  "mcp": {
+    "glama": {
+      "type": "local",
+      "command": ["uvx", "mcp-openapi-proxy"],
+      "environment": { "OPENAPI_SPEC_URL": "https://glama.ai/api/mcp/openapi.json" }
+    }
+  }
+}
+```
+
+</details>
+
+<details>
+<summary><b>Vibe</b> — <code>~/.vibe/config.toml</code> <code>[[mcp_servers]]</code></summary>
+
+```toml
+[[mcp_servers]]
+name = "glama"
+command = "uvx"
+args = ["mcp-openapi-proxy"]
+
+[mcp_servers.env]
+OPENAPI_SPEC_URL = "https://glama.ai/api/mcp/openapi.json"
+```
+
+</details>
+
+agy (headless) and letta cloud could not attach a stdio MCP server at all, so no config snippet applies: agy provides no way to enable MCP in headless mode, and letta cloud only accepts remote MCP servers.
+
+### Tips
+
+- **Big specs need `TOOL_WHITELIST`.** Large APIs (Asana, Render, Fly.io, Slack, NetBox) expose dozens of endpoints; whitelist the paths you need to keep the tool count manageable for clients.
+- **Dot-style paths need exact whitelist entries for now.** Slack-style paths like `/chat.postMessage` are not matched by prefix whitelisting — list each path exactly (issue #27 / PR #32).
+- **Slow remote specs can crash-loop short-timeout clients.** If a client kills the server before a large spec finishes downloading, fetch the spec once and point `OPENAPI_SPEC_URL` at a local `file://` copy (issue #28).
+- **Custom auth schemes** are handled via `API_AUTH_TYPE` (PR #25), e.g. `Token` for NetBox, or `api-key` with `API_AUTH_HEADER` for Virustotal/ElevenLabs-style header keys.
+
 ## Examples
 
 For testing you can run the uvx command as demonstrated in the examples then interact with the MCP server via JSON-RPC messages to list tools and resources. See the "JSON-RPC Testing" section below.
 
-### Glama Example
+Each example below is collapsed — click to expand.
+
+<details>
+<summary><b>Glama Example</b> — the most minimal config: just <code>OPENAPI_SPEC_URL</code>, no auth</summary>
 
 ![image](https://github.com/user-attachments/assets/84afdaa8-7b4f-4726-835f-64255ca970b7)
 
@@ -154,7 +287,10 @@ OPENAPI_SPEC_URL="https://glama.ai/api/mcp/openapi.json" uvx mcp-openapi-proxy
 
 Then refer to the [JSON-RPC Testing](#json-rpc-testing) section for instructions on listing resources and tools.
 
-### Fly.io Example
+</details>
+
+<details>
+<summary><b>Fly.io Example</b> — machines API with an API token</summary>
 
 ![image](https://github.com/user-attachments/assets/80abd7fa-ccca-4e35-b0dd-36ef82a236c5)
 
@@ -197,7 +333,10 @@ Update your MCP ecosystem configuration:
 
 After starting the service refer to the [JSON-RPC Testing](#json-rpc-testing) section for instructions on listing resources and tools.
 
-### Render Example
+</details>
+
+<details>
+<summary><b>Render Example</b> — manage hosted services with a tool whitelist</summary>
 
 ![image](https://github.com/user-attachments/assets/f1dee1bf-e330-41f1-a700-6386edd8895e)
 
@@ -243,7 +382,10 @@ OPENAPI_SPEC_URL="https://api-docs.render.com/openapi/6140fb3daeae351056086186" 
 
 Then refer to the [JSON-RPC Testing](#json-rpc-testing) section for instructions on listing resources and tools.
 
-### Slack Example
+</details>
+
+<details>
+<summary><b>Slack Example</b> — payload token stripping via JMESPath (<code>STRIP_PARAM</code>)</summary>
 
 ![image](https://github.com/user-attachments/assets/706adad5-3f1c-4f32-aef5-6a1af794aef3)
 
@@ -291,7 +433,10 @@ Update your configuration:
 
 After starting the service refer to the [JSON-RPC Testing](#json-rpc-testing) section for instructions on listing resources and tools.
 
-### GetZep Example
+</details>
+
+<details>
+<summary><b>GetZep Example</b> — project-generated spec with <code>Api-Key</code> auth</summary>
 
 ![image](https://github.com/user-attachments/assets/9a4fdabb-fa3d-4626-a50f-438147eadc9f)
 
@@ -339,7 +484,10 @@ Update your configuration:
 
 After starting the service refer to the [JSON-RPC Testing](#json-rpc-testing) section for instructions on listing resources and tools.
 
-### Virustotal Example
+</details>
+
+<details>
+<summary><b>Virustotal Example</b> — YAML spec + custom <code>x-apikey</code> auth header</summary>
 
 ![image](https://github.com/user-attachments/assets/d1760e58-a299-4004-9593-6dbaf3b685a1)
 
@@ -392,7 +540,10 @@ OPENAPI_SPEC_URL="https://raw.githubusercontent.com/matthewhand/mcp-openapi-prox
 
 After starting the service, refer to the [JSON-RPC Testing](#json-rpc-testing) section for instructions on listing resources and tools.
 
-### Notion Example
+</details>
+
+<details>
+<summary><b>Notion Example</b> — API version header via <code>EXTRA_HEADERS</code></summary>
 
 ![image](https://github.com/user-attachments/assets/45038bcf-9537-4337-8a90-8553ad3aa81b)
 
@@ -441,7 +592,10 @@ OPENAPI_SPEC_URL="https://storage.googleapis.com/versori-assets/public-specs/202
 
 After starting the service, refer to the [JSON-RPC Testing](#json-rpc-testing) section for instructions on listing resources and tools.
 
-### Asana Example
+</details>
+
+<details>
+<summary><b>Asana Example</b> — workspaces/tasks/projects with a whitelist and <code>SERVER_URL_OVERRIDE</code></summary>
 
 ![image](https://github.com/user-attachments/assets/087571dd-9e06-407e-905c-92815231f618)
 
@@ -492,7 +646,10 @@ ASANA_API_KEY="<your_asana_api_key>" OPENAPI_SPEC_URL="https://raw.githubusercon
 
 You can then use the MCP ecosystem to list and invoke tools for endpoints like `/dcim/devices/` and `/ipam/ip-addresses/`.
 
-### APIs.guru Example
+</details>
+
+<details>
+<summary><b>APIs.guru Example</b> — directory of thousands of public OpenAPI definitions, no auth</summary>
 
 APIs.guru provides a directory of OpenAPI definitions for thousands of public APIs. This example shows how to use mcp-openapi-proxy to expose the APIs.guru directory as MCP tools.
 
@@ -534,7 +691,10 @@ OPENAPI_SPEC_URL="https://raw.githubusercontent.com/APIs-guru/openapi-directory/
 
 You can then use the MCP ecosystem to list and invoke tools such as `listAPIs`, `getMetrics`, and `getProviders` that are defined in the APIs.guru directory.
 
-### NetBox Example
+</details>
+
+<details>
+<summary><b>NetBox Example</b> — IPAM/DCIM API with <code>Token</code> auth</summary>
 
 NetBox is an open-source IP address management (IPAM) and data center infrastructure management (DCIM) tool. This example demonstrates how to use mcp-openapi-proxy to expose the NetBox API as MCP tools.
 
@@ -579,7 +739,10 @@ OPENAPI_SPEC_URL="https://raw.githubusercontent.com/APIs-guru/openapi-directory/
 
 You can then use the MCP ecosystem to list and invoke tools for endpoints like `/dcim/devices/` and `/ipam/ip-addresses/`.
 
-### Box API Example
+</details>
+
+<details>
+<summary><b>Box API Example</b> — developer-token access to Box content</summary>
 
 You can integrate the Box Platform API using your own developer token for authenticated access to your Box account. This example demonstrates how to expose Box API endpoints as MCP tools.
 
@@ -606,7 +769,10 @@ You can now use the MCP ecosystem to list and invoke Box API tools. For integrat
 
 Note: developer api keys for free tier box users are limited to 60 minutes :(.  
 
-### WolframAlpha API Example
+</details>
+
+<details>
+<summary><b>WolframAlpha API Example</b> — computation API keyed by App ID</summary>
 
 ![image](https://github.com/user-attachments/assets/6a634d63-5734-4275-8876-6bacb8beabcc)
 
@@ -641,6 +807,8 @@ You can integrate the WolframAlpha API using your own App ID for authenticated a
   ```
 
 You can now use the MCP ecosystem to list and invoke WolframAlpha API tools. For integration tests, see `tests/integration/test_wolframalpha_integration.py`.
+
+</details>
 
 ## Troubleshooting
 


### PR DESCRIPTION
Fixes #35

## What changed

1. **Collapsed every per-API example** (Glama, Fly.io, Render, Slack, GetZep, Virustotal, Notion, Asana, APIs.guru, NetBox, Box, WolframAlpha) into `<details><summary><b>NAME Example</b> — one-line summary</summary>` blocks. GitHub markdown has no native tabs, so details/summary is the standard space-saver. All example content is preserved verbatim — just collapsed. The TOC is trimmed to match.

2. **New section "Verified Clients & Live Results (2026-06-12)"** ahead of Examples:
   - A results matrix per API example: tool count, the sample call actually proven against the live API on 2026-06-12, and extra env vars needed (including the new Render spec URL `render-public-api-1.json` and an elevenlabs row).
   - A client matrix for agent CLIs attached over stdio MCP: Codex, Gemini, Qwen, Kilocode, opencode, and Vibe all made native tool calls; none surfaced prompts/resources to the model; agy (headless) and letta cloud (remote-only) could not attach stdio MCP at all.
   - Per-client minimal sanitized config snippets in collapsed `<details>` blocks (placeholders only, no credentials).

3. **Tips note**: `TOOL_WHITELIST` for big specs; dot-style paths (Slack) need exact whitelist entries until #27 is fixed (PR #32); slow remote specs can crash-loop short-timeout clients — cache via `file://` (#28); custom auth schemes via `API_AUTH_TYPE` (PR #25).

## Notes for review

- The Examples-section restructuring may conflict with open PRs #21 / #30 / #31, which also touch example content. Merge order is flexible — happy to rebase this one last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)