### PR TITLE
docs(getzep): local Zep CE path — hosted endpoint 401s

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,9 @@ After starting the service refer to the [JSON-RPC Testing](#json-rpc-testing) se
 
 ### GetZep Example
 
+> **Note (2026):** GetZep's hosted endpoint (`api.getzep.com`) returns **401** for previously-working keys — the hosted free tier no longer accepts API keys. The example now targets a **self-hosted Zep CE**: see `examples/zep-ce/docker-compose.yml` (zep built from source tag v1.0.2 + `pgvector/pgvector:pg17`; the delisted `zepai/zep` image must be rebuilt via the official `Dockerfile.ce`). Auth quirk: Zep's scheme is literally `Api-Key`, which collides with the proxy's special `api-key` mode — use `API_AUTH_TYPE=api-key` with `API_KEY="Api-Key <your-secret>"`. Live-verified: 8 tools via `TOOL_WHITELIST=/sessions`; session create + read-back through the bridge.
+
+
 ![image](https://github.com/user-attachments/assets/9a4fdabb-fa3d-4626-a50f-438147eadc9f)
 
 GetZep offers a free cloud API for memory management with detailed endpoints. Since GetZep did not provide an official OpenAPI specification, this project includes a generated spec hosted on GitHub for convenience. Users can similarly generate OpenAPI specs for any REST API and reference them locally (e.g. `file:///path/to/spec.json`). Obtain an API key from [GetZep's documentation](https://docs.getzep.com/).

--- a/examples/getzep-claude_desktop_config.json
+++ b/examples/getzep-claude_desktop_config.json
@@ -7,9 +7,10 @@
       ],
       "env": {
         "OPENAPI_SPEC_URL": "https://raw.githubusercontent.com/matthewhand/mcp-openapi-proxy/refs/heads/main/examples/getzep.swagger.json",
-        "TOOL_WHITELIST": "/sessions",
-        "API_KEY": "${GETZEP_API_KEY}",
-        "API_AUTH_TYPE": "Api-Key"
+        "SERVER_URL_OVERRIDE": "http://localhost:8010/api/v2",
+        "API_KEY": "Api-Key ${ZEP_API_SECRET}",
+        "API_AUTH_TYPE": "api-key",
+        "TOOL_WHITELIST": "/sessions"
       }
     }
   }

--- a/examples/zep-ce/docker-compose.yml
+++ b/examples/zep-ce/docker-compose.yml
@@ -1,0 +1,44 @@
+name: zep-ce
+
+services:
+  zep:
+    # zepai/zep was removed from Docker Hub; built locally from
+    # github.com/getzep/zep tag v1.0.2 (legacy CE) via Dockerfile.ce.
+    image: zep-ce:local
+    ports:
+      - "8010:8000"
+    volumes:
+      - ./zep.yaml:/app/zep.yaml
+    environment:
+      - ZEP_CONFIG_FILE=zep.yaml
+    networks:
+      - zep-network
+    depends_on:
+      db:
+        condition: service_healthy
+  db:
+    # pgvector is REQUIRED: zep panics at startup if
+    # "CREATE EXTENSION IF NOT EXISTS vector" fails (src/lib/pg/db.go).
+    # postgres:17-alpine therefore cannot be reused.
+    image: pgvector/pgvector:pg17
+    restart: on-failure
+    shm_size: "128mb"
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+    networks:
+      - zep-network
+    healthcheck:
+      test: ["CMD", "pg_isready", "-q", "-d", "postgres", "-U", "postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    volumes:
+      - zep-db:/var/lib/postgresql/data
+
+volumes:
+  zep-db:
+
+networks:
+  zep-network:
+    driver: bridge

--- a/examples/zep-ce/zep.yaml
+++ b/examples/zep-ce/zep.yaml
@@ -1,0 +1,24 @@
+log:
+  level: info
+  format: console
+http:
+  host: 0.0.0.0
+  port: 8000
+  max_request_size: 5242880
+postgres:
+  user: postgres
+  password: postgres
+  host: db
+  port: 5432
+  database: postgres
+  schema_name: public
+  read_timeout: 30
+  write_timeout: 30
+  max_open_connections: 10
+carbon:
+  locale: en
+graphiti:
+  service_url: http://graphiti:8003
+api_secret: changeme-local-secret
+telemetry:
+  disabled: true


### PR DESCRIPTION
Fixes #38

- README note: hosted GetZep 401s; documents the self-hosted Zep CE path
- `examples/zep-ce/`: working docker-compose (zep-ce built from source v1.0.2 + pgvector) + zep.yaml
- example config updated: `SERVER_URL_OVERRIDE=http://localhost:8010/api/v2`, auth-collision workaround (`API_AUTH_TYPE=api-key` + `API_KEY="Api-Key <secret>"`)

Live-verified: 8 tools whitelisted to /sessions; session created and read back through the bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)