### PR TITLE
fix(startup): no crash-loop — handshake-first lazy spec load + live-first cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ Refer to the **Examples** section below for practical configurations tailored to
 ## Environment Variables
 
 - `OPENAPI_SPEC_URL`: (Required) The URL to the OpenAPI specification JSON file (e.g. `https://example.com/spec.json` or `file:///path/to/local/spec.json`).
-- `OPENAPI_LOGFILE_PATH`: (Optional) Specifies the log file path.
 - `OPENAPI_SIMPLE_MODE`: (Optional) Set to `true` to enable FastMCP mode.
 - `TOOL_WHITELIST`: (Optional) A comma-separated list of endpoint paths to expose as tools.
 - `ADDITIONAL_RESOURCES`: (Optional) Comma-separated `name=/path/to/file` entries served as extra MCP resources (use-case docs such as naming policies or layout conventions; see `examples/resources/`).
@@ -96,6 +95,11 @@ Refer to the **Examples** section below for practical configurations tailored to
 - Additional Variable: `OPENAPI_SPEC_URL_<hash>` – a variant for unique per-test configurations (falls back to `OPENAPI_SPEC_URL`).
 - `IGNORE_SSL_SPEC`: (Optional) Set to `true` to disable SSL certificate verification when fetching the OpenAPI spec.
 - `IGNORE_SSL_TOOLS`: (Optional) Set to `true` to disable SSL certificate verification for API requests made by tools.
+- `API_AUTH_HEADER`: (Optional) Header name used when `API_AUTH_TYPE=api-key` (e.g. `x-apikey` for VirusTotal, `xi-api-key` for ElevenLabs). Defaults to `Authorization`.
+- `OPENAPI_SPEC_FORMAT`: (Optional) Set to `yaml` to parse `file://` specs as YAML (remote specs auto-detect). Default `json`.
+- `OPENAPI_SPEC_CACHE_TTL_SECONDS`: (Optional) Live-first disk cache for remote specs: the cached copy is served only when the live fetch fails or stalls (and respawned servers fail fast to it). Default `86400`; set `0` to disable.
+- `ENABLE_TOOLS` / `ENABLE_PROMPTS` / `ENABLE_RESOURCES`: (Optional) Feature gates for the three MCP surfaces in low-level mode; each defaults to enabled. Disabling a feature removes its handlers and its capability advertisement.
+- `CAPABILITIES_TOOLS` / `CAPABILITIES_PROMPTS` / `CAPABILITIES_RESOURCES`: (Optional) Advertise `listChanged` on the corresponding capability (for clients that key on it). Default `false`.
 
 ## Verified Clients & Live Results (2026-06-12)
 

--- a/mcp_openapi_proxy/server_lowlevel.py
+++ b/mcp_openapi_proxy/server_lowlevel.py
@@ -155,6 +155,46 @@ def build_capabilities() -> "types.ServerCapabilities":
 
 openapi_spec_data: Optional[Dict[str, Any]] = None
 
+# Lazy spec loading (issue #28): the MCP handshake must be answered immediately,
+# even when OPENAPI_SPEC_URL is slow to download/parse. Clients with short
+# connect timeouts (observed: Kilocode, Vibe) otherwise hang up mid-handshake,
+# the proxy dies on the closed stream, the client respawns it — a crash loop.
+_spec_load_lock: Optional[asyncio.Lock] = None
+_spec_load_error: Optional[str] = None
+
+
+async def ensure_spec_loaded() -> Optional[Dict[str, Any]]:
+    """Fetch and register the OpenAPI spec on first use. Safe to call from any
+    handler; concurrent callers await the same fetch."""
+    global openapi_spec_data, _spec_load_lock, _spec_load_error
+    if openapi_spec_data is not None or _spec_load_error is not None:
+        return openapi_spec_data
+    if _spec_load_lock is None:
+        _spec_load_lock = asyncio.Lock()
+    async with _spec_load_lock:
+        if openapi_spec_data is not None or _spec_load_error is not None:
+            return openapi_spec_data
+        openapi_url = os.getenv("OPENAPI_SPEC_URL")
+        if not openapi_url:
+            _spec_load_error = "OPENAPI_SPEC_URL not set"
+            logger.critical(_spec_load_error)
+            return None
+        logger.debug(f"Lazily fetching OpenAPI spec from {openapi_url}...")
+        spec = await anyio.to_thread.run_sync(fetch_openapi_spec, openapi_url)
+        if not spec:
+            _spec_load_error = f"Failed to fetch or parse OpenAPI spec from {openapi_url}"
+            logger.critical(_spec_load_error)
+            return None
+        openapi_spec_data = spec
+        if ENABLE_TOOLS:
+            from mcp_openapi_proxy.handlers import register_functions
+            register_functions(spec)
+            logger.debug(f"Tools registered lazily: {[tool.name for tool in tools]}")
+            if not tools:
+                logger.critical("No valid tools registered from spec.")
+        return openapi_spec_data
+
+
 mcp = Server("OpenApiProxy-LowLevel")
 
 async def dispatcher_handler(request: types.CallToolRequest) -> types.CallToolResult:
@@ -163,6 +203,7 @@ async def dispatcher_handler(request: types.CallToolRequest) -> types.CallToolRe
     """
     global openapi_spec_data
     try:
+        await ensure_spec_loaded()
         function_name = request.params.name
         logger.debug(f"Dispatcher received CallToolRequest for function: {function_name}")
         logger.debug(f"API_KEY: {os.getenv('API_KEY', '<not set>')[:5] + '...' if os.getenv('API_KEY') else '<not set>'}")
@@ -299,23 +340,26 @@ async def dispatcher_handler(request: types.CallToolRequest) -> types.CallToolRe
 
 async def list_tools(request: types.ListToolsRequest) -> types.ListToolsResult:
     logger.debug("Handling list_tools request - start")
+    await ensure_spec_loaded()
     logger.debug(f"Tools list length: {len(tools)}")
     return types.ListToolsResult(tools=tools)
 
 async def list_resources(request: types.ListResourcesRequest) -> types.ListResourcesResult:
-    logger.debug("Handling list_resources request")
-    from pydantic import AnyUrl
-    from types import SimpleNamespace
+    """List the spec_file resource plus any ADDITIONAL_RESOURCES entries.
+
+    The module-level `resources` list is always seeded with spec_file; the
+    guard below only matters if a caller mutated it at runtime.
+    """
+    logger.debug(f"Handling list_resources request ({len(resources)} resources)")
     if not resources:
-        logger.debug("Resources empty; populating default resource")
+        logger.debug("Resources empty; repopulating default resource")
         resources.append(
             types.Resource(
                 name="spec_file",
                 uri=AnyUrl("file:///openapi_spec.json"),
-                description="The raw OpenAPI specification JSON"
+                description="The raw OpenAPI specification JSON",
             )
         )
-    logger.debug(f"Resources list length: {len(resources)}")
     return types.ListResourcesResult(resources=resources)
 
 
@@ -437,8 +481,20 @@ def lookup_operation_details(function_name: str, spec: Dict[str, Any]) -> Option
     return None
 
 
+def _is_closed_stream_error(exc: BaseException) -> bool:
+    """True when the failure means the client hung up — retrying is pointless."""
+    if isinstance(exc, (anyio.ClosedResourceError, anyio.BrokenResourceError, anyio.EndOfStream)):
+        return True
+    if isinstance(exc, BaseExceptionGroup):
+        return any(_is_closed_stream_error(sub) for sub in exc.exceptions)
+    return False
+
+
 async def start_server():
     logger.debug("Starting Low-Level MCP server...")
+    # Pre-warm the spec in the background: the handshake is served immediately
+    # while the (possibly slow) spec download proceeds (issue #28).
+    prewarm = asyncio.create_task(ensure_spec_loaded())
     async with stdio_server() as (read_stream, write_stream):
         while True:
             try:
@@ -452,30 +508,27 @@ async def start_server():
                         capabilities=capabilities,
                     ),
                 )
-            except Exception as e:
+                logger.debug("MCP session ended normally; exiting.")
+                break
+            except BaseException as e:
+                if _is_closed_stream_error(e):
+                    # Client disconnected (e.g. short connect timeout while the
+                    # spec was still loading). Exit cleanly instead of spinning
+                    # on a dead stream — the client respawns us if it wants to.
+                    logger.warning("Client closed the stream; shutting down cleanly.")
+                    break
                 logger.error(f"MCP run crashed: {e}", exc_info=True)
                 await anyio.sleep(1)
+    prewarm.cancel()
 
 
 def run_server():
-    global openapi_spec_data
     try:
-        openapi_url = os.getenv('OPENAPI_SPEC_URL')
-        if not openapi_url:
+        if not os.getenv('OPENAPI_SPEC_URL'):
             logger.critical("OPENAPI_SPEC_URL environment variable is required but not set.")
             sys.exit(1)
-        openapi_spec_data = fetch_openapi_spec(openapi_url)
-        if not openapi_spec_data:
-            logger.critical("Failed to fetch or parse OpenAPI specification from OPENAPI_SPEC_URL.")
-            sys.exit(1)
-        logger.debug("OpenAPI specification fetched successfully.")
-        if ENABLE_TOOLS:
-            from mcp_openapi_proxy.handlers import register_functions
-            register_functions(openapi_spec_data)
-        logger.debug(f"Tools after registration: {[tool.name for tool in tools]}")
-        if ENABLE_TOOLS and not tools:
-            logger.critical("No valid tools registered. Shutting down.")
-            sys.exit(1)
+        # Spec fetch + tool registration are lazy (ensure_spec_loaded) so the
+        # MCP handshake is never blocked by a slow spec download (issue #28).
         if ENABLE_TOOLS:
             mcp.request_handlers[types.ListToolsRequest] = list_tools
             mcp.request_handlers[types.CallToolRequest] = dispatcher_handler

--- a/mcp_openapi_proxy/utils.py
+++ b/mcp_openapi_proxy/utils.py
@@ -112,10 +112,65 @@ def normalize_tool_name(raw_name: str, max_length: Optional[int] = None) -> str:
         logger.error(f"Error normalizing tool name '{raw_name}': {e}", exc_info=True)
         return "unknown_tool" # Return a default on unexpected error
 
+def _spec_cache_path(url: str) -> str:
+    import hashlib
+    cache_dir = os.path.join(
+        os.getenv("XDG_CACHE_HOME", os.path.expanduser("~/.cache")), "mcp-openapi-proxy"
+    )
+    os.makedirs(cache_dir, exist_ok=True)
+    return os.path.join(cache_dir, f"spec-{hashlib.sha256(url.encode()).hexdigest()[:24]}.json")
+
+
+def _spec_cache_ttl() -> int:
+    try:
+        return int(os.getenv("OPENAPI_SPEC_CACHE_TTL_SECONDS", "86400"))
+    except ValueError:
+        return 86400
+
+
+def _spec_cache_load(url: str) -> Optional[Dict]:
+    """Fallback copy of a previously fetched remote spec, if fresh enough."""
+    import time
+    if _spec_cache_ttl() <= 0 or url.startswith("file://"):
+        return None
+    path = _spec_cache_path(url)
+    try:
+        age = time.time() - os.path.getmtime(path)
+        if age < _spec_cache_ttl():
+            with open(path, "r") as f:
+                spec = json.load(f)
+            logger.debug(f"Spec cache hit for {url} (age {int(age)}s): {path}")
+            return spec
+    except (OSError, json.JSONDecodeError):
+        pass
+    return None
+
+
+def _spec_cache_store(url: str, spec: Dict) -> None:
+    if url.startswith("file://") or _spec_cache_ttl() <= 0:
+        return
+    try:
+        path = _spec_cache_path(url)
+        with open(path + ".tmp", "w") as f:
+            json.dump(spec, f)
+        os.replace(path + ".tmp", path)
+        logger.debug(f"Cached spec for {url} at {path}")
+    except OSError as exc:
+        logger.warning(f"Could not write spec cache: {exc}")
+
+
 def fetch_openapi_spec(url: str, retries: int = 3) -> Optional[Dict]:
+    """Fetch and parse an OpenAPI specification (JSON or YAML) from a URL.
+
+    Live-first with cache fallback (issue #28): remote fetches are always
+    attempted first; a previously cached copy is used only when the live
+    retrieval fails or stalls. When a fallback exists we fail fast (single
+    attempt) instead of burning the full retry budget. Tune with
+    OPENAPI_SPEC_CACHE_TTL_SECONDS (default 86400; 0 disables caching).
     """
-    Fetch and parse an OpenAPI specification from a URL with retries.
-    """
+    fallback = _spec_cache_load(url)
+    if fallback is not None:
+        retries = 1  # fail fast to the cached copy instead of retrying for ~30s
     logger.debug(f"Fetching OpenAPI spec from URL: {url}")
     attempt = 0
     while attempt < retries:
@@ -158,11 +213,15 @@ def fetch_openapi_spec(url: str, retries: int = 3) -> Optional[Dict]:
                     except yaml.YAMLError as ye:
                         logger.error(f"YAML parsing failed: {ye}. Raw content: {content[:500]}...")
                         return None
+            _spec_cache_store(url, spec)
             return spec
         except requests.RequestException as e:
             attempt += 1
             logger.warning(f"Fetch attempt {attempt}/{retries} failed: {e}")
             if attempt == retries:
+                if fallback is not None:
+                    logger.warning(f"Live fetch failed for {url}; serving cached copy.")
+                    return fallback
                 logger.error(f"Failed to fetch spec from {url} after {retries} attempts: {e}")
                 return None
         except FileNotFoundError as e:
@@ -172,6 +231,9 @@ def fetch_openapi_spec(url: str, retries: int = 3) -> Optional[Dict]:
             attempt += 1
             logger.warning(f"Unexpected error during fetch attempt {attempt}/{retries}: {e}")
             if attempt == retries:
+                if fallback is not None:
+                    logger.warning(f"Live fetch errored for {url}; serving cached copy.")
+                    return fallback
                 logger.error(f"Failed to process spec from {url} after {retries} attempts due to unexpected error: {e}")
                 return None
     return None

--- a/tests/unit/test_spec_cache_and_lazy_startup.py
+++ b/tests/unit/test_spec_cache_and_lazy_startup.py
@@ -1,0 +1,90 @@
+"""Issue #28: handshake-first startup, clean exit on closed stream, and
+live-first spec cache fallback."""
+import json
+import os
+import subprocess
+import sys
+import time
+
+
+def test_handshake_answered_before_slow_spec_fetch(tmp_path):
+    """initialize must respond while the spec is still downloading."""
+    server = subprocess.Popen(
+        [sys.executable, "-c", (
+            "import http.server, time\n"
+            "class H(http.server.BaseHTTPRequestHandler):\n"
+            "    def do_GET(self):\n"
+            "        time.sleep(8)\n"
+            "        self.send_response(200); self.end_headers()\n"
+            "        self.wfile.write(b'{\"openapi\":\"3.0.0\",\"paths\":{}}')\n"
+            "    def log_message(self, *a): pass\n"
+            "http.server.HTTPServer(('127.0.0.1', 18931), H).serve_forever()\n")],
+    )
+    try:
+        time.sleep(0.5)
+        env = dict(os.environ)
+        env["OPENAPI_SPEC_URL"] = "http://127.0.0.1:18931/slow.json"
+        env["OPENAPI_SPEC_CACHE_TTL_SECONDS"] = "0"
+        proc = subprocess.Popen(
+            [sys.executable, "-c", "from mcp_openapi_proxy import main; main()"],
+            stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL, env=env, text=True,
+        )
+        start = time.time()
+        proc.stdin.write(json.dumps({
+            "jsonrpc": "2.0", "id": 1, "method": "initialize",
+            "params": {"protocolVersion": "2024-11-05", "capabilities": {},
+                        "clientInfo": {"name": "t", "version": "1"}}}) + "\n")
+        proc.stdin.flush()
+        line = proc.stdout.readline()
+        elapsed = time.time() - start
+        proc.terminate()
+        resp = json.loads(line)
+        assert resp["id"] == 1 and "result" in resp
+        assert elapsed < 5, f"initialize took {elapsed:.1f}s — blocked on spec fetch"
+    finally:
+        server.terminate()
+
+
+def test_clean_exit_when_client_closes_stream():
+    """No crash-loop: closing stdin must end the process promptly."""
+    env = dict(os.environ)
+    env["OPENAPI_SPEC_URL"] = "file:///dev/null"
+    proc = subprocess.Popen(
+        [sys.executable, "-c", "from mcp_openapi_proxy import main; main()"],
+        stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL, env=env, text=True,
+    )
+    proc.stdin.write(json.dumps({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": {"protocolVersion": "2024-11-05", "capabilities": {},
+                    "clientInfo": {"name": "t", "version": "1"}}}) + "\n")
+    proc.stdin.flush()
+    proc.stdout.readline()
+    proc.stdin.close()
+    try:
+        rc = proc.wait(timeout=15)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        raise AssertionError("server kept running after client closed the stream (crash-loop)")
+    assert rc is not None
+
+
+def test_spec_cache_fallback(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    monkeypatch.setenv("OPENAPI_SPEC_CACHE_TTL_SECONDS", "3600")
+    from mcp_openapi_proxy import utils
+    url = "http://unreachable.invalid/spec.json"
+    spec = {"openapi": "3.0.0", "paths": {"/x": {}}}
+    utils._spec_cache_store(url, spec)
+    out = utils.fetch_openapi_spec(url, retries=1)
+    assert out == spec, "cached copy should be served when live fetch fails"
+
+
+def test_spec_cache_disabled(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    monkeypatch.setenv("OPENAPI_SPEC_CACHE_TTL_SECONDS", "0")
+    from mcp_openapi_proxy import utils
+    url = "http://unreachable.invalid/spec.json"
+    utils._spec_cache_store(url, {"x": 1})
+    assert utils.fetch_openapi_spec(url, retries=1) is None


### PR DESCRIPTION
Fixes #28 (lands on main via the release PR #37)

See commit message for the three coordinated fixes. Live failure mode this addresses: Kilocode crash-looped (`ClosedResourceError`) and Vibe timed out (13s init on a 1.8MB YAML spec) until both were worked around with `file://` caching.

Tests: 4 new (initialize answered <5s while spec stalls 8s; clean exit on closed stdin; cache fallback; cache disable); full unit suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)