### PR TITLE
feat: add Dockerfile and glama.json for Glama MCP directory listing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# Dockerfile for mcp-openapi-proxy (https://github.com/matthewhand/mcp-openapi-proxy)
+# Used by the Glama MCP directory to build and host the server.
+#
+# Build:
+#   docker build -t mcp-openapi-proxy .
+# Run (stdio MCP server; OPENAPI_SPEC_URL is required):
+#   docker run -i --rm -e OPENAPI_SPEC_URL=https://example.com/openapi.json mcp-openapi-proxy
+
+FROM python:3.12-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+WORKDIR /app
+
+# Copy project metadata and sources, then install the package.
+COPY pyproject.toml README.md LICENSE ./
+COPY mcp_openapi_proxy ./mcp_openapi_proxy
+
+RUN pip install --no-cache-dir .
+
+# Required: URL (or file:// path) of the OpenAPI specification to expose.
+# See README.md for the full list of optional variables
+# (API_KEY, TOOL_WHITELIST, SERVER_URL_OVERRIDE, EXTRA_HEADERS, DEBUG, ...).
+ENV OPENAPI_SPEC_URL=""
+
+ENTRYPOINT ["mcp-openapi-proxy"]

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["matthewhand"]
+}

--- a/tests/unit/test_dockerfile.py
+++ b/tests/unit/test_dockerfile.py
@@ -1,0 +1,72 @@
+"""
+Unit tests for the Glama deployment artifacts: Dockerfile and glama.json.
+
+Glama's MCP directory (https://glama.ai/mcp/servers) requires a Dockerfile at
+the repository root so the server can be built and hosted, and a glama.json
+manifest declaring the maintainers. These tests validate the static contract
+without building any image.
+"""
+
+import json
+import os
+import re
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+DOCKERFILE_PATH = os.path.join(REPO_ROOT, "Dockerfile")
+GLAMA_JSON_PATH = os.path.join(REPO_ROOT, "glama.json")
+PYPROJECT_PATH = os.path.join(REPO_ROOT, "pyproject.toml")
+
+PACKAGE_NAME = "mcp-openapi-proxy"
+
+
+def _read(path):
+    with open(path, "r", encoding="utf-8") as f:
+        return f.read()
+
+
+def test_dockerfile_exists_at_repo_root():
+    assert os.path.isfile(DOCKERFILE_PATH), "Dockerfile must exist at the repository root for the Glama listing"
+
+
+def test_dockerfile_uses_python_slim_base():
+    content = _read(DOCKERFILE_PATH)
+    assert re.search(r"^FROM\s+python:3\.\d+-slim", content, re.MULTILINE), (
+        "Dockerfile should be based on a python slim image"
+    )
+
+
+def test_dockerfile_entrypoint_is_console_script():
+    content = _read(DOCKERFILE_PATH)
+    match = re.search(r"^ENTRYPOINT\s+(.+)$", content, re.MULTILINE)
+    assert match, "Dockerfile must declare an ENTRYPOINT"
+    assert PACKAGE_NAME in match.group(1), (
+        f"ENTRYPOINT must invoke the {PACKAGE_NAME!r} console script"
+    )
+
+
+def test_dockerfile_installs_package():
+    content = _read(DOCKERFILE_PATH)
+    assert re.search(r"pip\s+install\b", content), "Dockerfile must pip install the package"
+
+
+def test_dockerfile_documents_spec_url_env():
+    content = _read(DOCKERFILE_PATH)
+    assert "OPENAPI_SPEC_URL" in content, (
+        "Dockerfile should reference the OPENAPI_SPEC_URL environment variable"
+    )
+
+
+def test_dockerfile_entrypoint_matches_pyproject_script():
+    pyproject = _read(PYPROJECT_PATH)
+    assert re.search(
+        rf"^{re.escape(PACKAGE_NAME)}\s*=", pyproject, re.MULTILINE
+    ), f"pyproject.toml must define the {PACKAGE_NAME!r} console script"
+    assert f'name = "{PACKAGE_NAME}"' in pyproject
+
+
+def test_glama_manifest_exists_and_is_valid():
+    assert os.path.isfile(GLAMA_JSON_PATH), "glama.json must exist at the repository root"
+    manifest = json.loads(_read(GLAMA_JSON_PATH))
+    assert manifest.get("$schema") == "https://glama.ai/mcp/schemas/server.json"
+    maintainers = manifest.get("maintainers")
+    assert isinstance(maintainers, list) and "matthewhand" in maintainers


### PR DESCRIPTION
Fixes #13

The [Glama MCP directory listing](https://glama.ai/mcp/servers/matthewhand/mcp-openapi-proxy) flags this server as missing a Dockerfile, which blocks Glama from building/hosting it for its users.

## Changes
- **`Dockerfile`** (repo root): `python:3.12-slim` base, `pip install .` of the package, `ENTRYPOINT ["mcp-openapi-proxy"]` (the console script from `pyproject.toml`), with `OPENAPI_SPEC_URL` declared/documented as the required env var.
- **`glama.json`**: manifest per Glama's schema (`https://glama.ai/mcp/schemas/server.json`) declaring `maintainers: ["matthewhand"]`.
- **`tests/unit/test_dockerfile.py`** (written first, TDD): asserts the Dockerfile exists at repo root, uses a python slim base, pip-installs the package, names the `mcp-openapi-proxy` entrypoint matching the `pyproject.toml` console script, references `OPENAPI_SPEC_URL`, and that `glama.json` is valid with the right schema/maintainers.

## Validation
- No `docker build` performed (disk constraint); the Dockerfile contract is validated statically via the new unit tests.
- Full unit suite: **116 passed** (109 pre-existing + 7 new).

## Remaining manual step
Per the issue, the listing must be claimed at glama.ai and the Dockerfile deployed from the admin page once this lands on the default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)