### PR TITLE
fix: accept literal \n as EXTRA_HEADERS separator for multiple headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Refer to the **Examples** section below for practical configurations tailored to
 - `API_AUTH_TYPE`: (Optional) Overrides the default `Bearer` Authorization scheme. `api-key` sends the key in the header named by `API_AUTH_HEADER`; any other value is used as a custom scheme prefix (e.g. `Token` for NetBox → `Authorization: Token <key>`).
 - `STRIP_PARAM`: (Optional) JMESPath expression to strip unwanted parameters (e.g. `token` for Slack).
 - `DEBUG`: (Optional) Enables verbose debug logging when set to "true", "1", or "yes".
-- `EXTRA_HEADERS`: (Optional) Additional HTTP headers in "Header: Value" format (one per line) to attach to outgoing API requests.
+- `EXTRA_HEADERS`: (Optional) Additional HTTP headers in "Header: Value" format to attach to outgoing API requests. Separate multiple headers with newlines or the literal `\n` sequence (handy in JSON configs), e.g. `"X-Csrf-Token: abc\nCookie: session=xyz"`.
 - `SERVER_URL_OVERRIDE`: (Optional) Overrides the base URL from the OpenAPI specification when set, useful for custom deployments.
 - `TOOL_NAME_MAX_LENGTH`: (Optional) Truncates tool names to a max length.
 - Additional Variable: `OPENAPI_SPEC_URL_<hash>` – a variant for unique per-test configurations (falls back to `OPENAPI_SPEC_URL`).

--- a/mcp_openapi_proxy/utils.py
+++ b/mcp_openapi_proxy/utils.py
@@ -361,11 +361,17 @@ def detect_response_type(response_text: str) -> Tuple[types.TextContent, str]:
 def get_additional_headers() -> Dict[str, str]:
     """
     Parse additional headers from EXTRA_HEADERS environment variable.
+
+    Headers are separated by real newlines or by the literal two-character
+    sequence "\\n" (for configs that cannot express real newlines, e.g.
+    claude_desktop_config.json env values). See issue #17.
     """
     headers = {}
     extra_headers = os.getenv("EXTRA_HEADERS")
     if extra_headers:
         logger.debug(f"Parsing EXTRA_HEADERS: {extra_headers}")
+        # Treat literal "\n" sequences as separators in addition to real newlines.
+        extra_headers = extra_headers.replace("\\n", "\n")
         for line in extra_headers.splitlines():
             line = line.strip()
             if ":" in line:

--- a/tests/unit/test_additional_headers.py
+++ b/tests/unit/test_additional_headers.py
@@ -56,6 +56,28 @@ def test_get_additional_headers_multiple(mock_env):
     headers = get_additional_headers()
     assert headers == {"X-Test": "Value", "X-Another": "More"}, "Multiple headers not parsed correctly"
 
+def test_get_additional_headers_literal_backslash_n_separator(mock_env):
+    # Literal two-character "\n" sequence (e.g. from configs that cannot
+    # express real newlines) must also act as a header separator. See issue #17.
+    os.environ["EXTRA_HEADERS"] = "X-Test: Value\\nX-Another: More"
+    headers = get_additional_headers()
+    assert headers == {"X-Test": "Value", "X-Another": "More"}, \
+        "Multiple headers separated by literal \\n not parsed correctly"
+
+def test_get_additional_headers_literal_backslash_n_value_with_colon(mock_env):
+    # Values containing colons (tokens, cookies) must survive splitting.
+    os.environ["EXTRA_HEADERS"] = "x-csrf-token: abc:123\\nCookie: session=a:b"
+    headers = get_additional_headers()
+    assert headers == {"x-csrf-token": "abc:123", "Cookie": "session=a:b"}, \
+        "Header values containing colons not parsed correctly with literal \\n separator"
+
+def test_get_additional_headers_mixed_separators(mock_env):
+    # Real newlines and literal "\n" sequences can be mixed.
+    os.environ["EXTRA_HEADERS"] = "X-One: 1\nX-Two: 2\\nX-Three: 3"
+    headers = get_additional_headers()
+    assert headers == {"X-One": "1", "X-Two": "2", "X-Three": "3"}, \
+        "Mixed real-newline and literal \\n separators not parsed correctly"
+
 @pytest.mark.asyncio
 async def test_lowlevel_dispatcher_with_headers(mock_env, mock_requests, monkeypatch):
     os.environ["EXTRA_HEADERS"] = "X-Custom: Foo"


### PR DESCRIPTION
Fixes #17

## Problem

Passing multiple headers via `EXTRA_HEADERS` requires newline-separated `Header: Value` lines, but many client configs (e.g. `claude_desktop_config.json` env values) cannot easily express real newlines. The issue reporter first tried commas (which would corrupt values like cookies) before discovering the newline separator, which was also undocumented.

## Fix

- `get_additional_headers()` in `mcp_openapi_proxy/utils.py` (the single parse site, used by `handlers.py`, `server_lowlevel.py`, and `server_fastmcp.py`) now converts literal two-character `\n` sequences to real newlines before splitting, so both separators work and can be mixed.
- Existing real-newline behavior is unchanged, and header values containing colons (CSRF tokens, cookies) are preserved.
- README documents the accepted separators with an example.

## Tests (TDD)

Added three RED-first tests in `tests/unit/test_additional_headers.py`:
- multiple headers separated by literal `\n`
- values containing colons with the literal `\n` separator
- mixed real-newline and literal `\n` separators

Full unit suite: 112 passed (was 109).

🤖 Generated with [Claude Code](https://claude.com/claude-code)