### PR TITLE
fix: include items in JSON Schema for array parameters

### DIFF
--- a/mcp_openapi_proxy/openapi.py
+++ b/mcp_openapi_proxy/openapi.py
@@ -219,6 +219,13 @@ def register_functions(spec: Dict) -> List[types.Tool]:
                             "type": schema_type,
                             "description": param_details.get('description', f"{param_in} parameter {param_name}")
                         }
+                        # Arrays must carry an items schema (required by JSON Schema
+                        # consumers such as the OpenAI API); fall back to string items.
+                        if schema_type == 'array':
+                            items_schema = param_schema.get('items')
+                            if not isinstance(items_schema, dict) or not items_schema:
+                                items_schema = {"type": "string"}
+                            input_schema['properties'][param_name]['items'] = items_schema
                         # Add format if available
                         if param_schema.get('format'):
                              input_schema['properties'][param_name]['format'] = param_schema.get('format')
@@ -255,7 +262,13 @@ def register_functions(spec: Dict) -> List[types.Tool]:
                                body_schema = json_content['schema']
                                # If body schema is object with properties, merge them
                                if body_schema.get('type') == 'object' and 'properties' in body_schema:
-                                    input_schema['properties'].update(body_schema['properties'])
+                                    for prop_name, prop_schema in body_schema['properties'].items():
+                                         if isinstance(prop_schema, dict) and prop_schema.get('type') == 'array' and not isinstance(prop_schema.get('items'), dict):
+                                              # Ensure array properties carry items (required by
+                                              # consumers such as the OpenAI API).
+                                              prop_schema = dict(prop_schema)
+                                              prop_schema['items'] = {"type": "string"}
+                                         input_schema['properties'][prop_name] = prop_schema
                                     if 'required' in body_schema and isinstance(body_schema['required'], list):
                                          # Add required body properties, avoiding duplicates
                                          for req_prop in body_schema['required']:

--- a/mcp_openapi_proxy/server_fastmcp.py
+++ b/mcp_openapi_proxy/server_fastmcp.py
@@ -115,13 +115,22 @@ def list_functions(*, env_key: str = "OPENAPI_SPEC_URL") -> str:
                 input_schema['required'].append(param_name)
             for param in operation.get("parameters", []):
                 param_name = param.get("name")
-                param_type = param.get("type", "string")
-                if param_type not in ["string", "integer", "boolean", "number"]:
+                param_schema = param.get("schema", {}) if isinstance(param.get("schema"), dict) else {}
+                param_type = param_schema.get("type", param.get("type", "string"))
+                if param_type not in ["string", "integer", "boolean", "number", "array"]:
                     param_type = "string"
-                input_schema["properties"][param_name] = {
+                prop = {
                     "type": param_type,
                     "description": param.get("description", f"{param.get('in', 'unknown')} parameter {param_name}")
                 }
+                if param_type == "array":
+                    # Arrays must carry an items schema (required by JSON Schema
+                    # consumers such as the OpenAI API); fall back to string items.
+                    items_schema = param_schema.get("items", param.get("items"))
+                    if not isinstance(items_schema, dict) or not items_schema:
+                        items_schema = {"type": "string"}
+                    prop["items"] = items_schema
+                input_schema["properties"][param_name] = prop
                 if param.get("required", False) and param_name not in input_schema['required']:
                     input_schema["required"].append(param_name)
             functions[function_name] = {

--- a/tests/unit/test_input_schema_generation.py
+++ b/tests/unit/test_input_schema_generation.py
@@ -48,6 +48,160 @@ class TestInputSchemaGeneration(unittest.TestCase):
         # Restore is_tool_whitelisted
         utils.is_tool_whitelisted = self.old_is_tool_whitelisted
 
+    def test_array_param_with_items_includes_items(self):
+        # Issue #16: array parameters must include their `items` schema so
+        # OpenAI tool_use does not reject the generated JSON Schema.
+        spec = {
+            "openapi": "3.0.0",
+            "servers": [{"url": "https://dummy-base.com"}],
+            "paths": {
+                "/pet/findByTags": {
+                    "get": {
+                        "summary": "Finds Pets by tags.",
+                        "operationId": "findPetsByTags",
+                        "parameters": [
+                            {
+                                "name": "tags",
+                                "in": "query",
+                                "description": "Tags to filter by",
+                                "required": True,
+                                "explode": True,
+                                "schema": {"type": "array", "items": {"type": "string"}}
+                            }
+                        ],
+                        "responses": {"200": {"description": "OK"}}
+                    }
+                }
+            }
+        }
+        registered_tools = register_functions(spec)
+        self.assertEqual(len(registered_tools), 1)
+        prop = registered_tools[0].inputSchema["properties"]["tags"]
+        self.assertEqual(prop["type"], "array")
+        self.assertEqual(prop.get("items"), {"type": "string"})
+
+    def test_array_param_without_items_gets_default_items(self):
+        # OpenAI requires `items` for arrays; fall back to string items
+        # when the spec omits them.
+        spec = {
+            "openapi": "3.0.0",
+            "servers": [{"url": "https://dummy-base.com"}],
+            "paths": {
+                "/things": {
+                    "get": {
+                        "summary": "List things",
+                        "parameters": [
+                            {
+                                "name": "ids",
+                                "in": "query",
+                                "required": False,
+                                "schema": {"type": "array"}
+                            }
+                        ],
+                        "responses": {"200": {"description": "OK"}}
+                    }
+                }
+            }
+        }
+        registered_tools = register_functions(spec)
+        self.assertEqual(len(registered_tools), 1)
+        prop = registered_tools[0].inputSchema["properties"]["ids"]
+        self.assertEqual(prop["type"], "array")
+        self.assertEqual(prop.get("items"), {"type": "string"})
+
+    def test_request_body_array_property_includes_items(self):
+        # Array properties merged from a requestBody must also carry `items`,
+        # including a fallback when the spec omits them.
+        spec = {
+            "openapi": "3.0.0",
+            "servers": [{"url": "https://dummy-base.com"}],
+            "paths": {
+                "/pets": {
+                    "post": {
+                        "summary": "Create a pet",
+                        "requestBody": {
+                            "required": True,
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "object",
+                                        "properties": {
+                                            "tags": {
+                                                "type": "array",
+                                                "items": {"type": "string"}
+                                            },
+                                            "photoUrls": {
+                                                "type": "array"
+                                            }
+                                        },
+                                        "required": ["tags"]
+                                    }
+                                }
+                            }
+                        },
+                        "responses": {"200": {"description": "OK"}}
+                    }
+                }
+            }
+        }
+        registered_tools = register_functions(spec)
+        self.assertEqual(len(registered_tools), 1)
+        props = registered_tools[0].inputSchema["properties"]
+        self.assertEqual(props["tags"]["type"], "array")
+        self.assertEqual(props["tags"].get("items"), {"type": "string"})
+        self.assertEqual(props["photoUrls"]["type"], "array")
+        self.assertEqual(props["photoUrls"].get("items"), {"type": "string"})
+
+    def test_fastmcp_array_param_includes_items(self):
+        # The FastMCP path builds its own inputSchema and must also emit
+        # array types with `items` (falling back to string items).
+        import json
+        import os
+        from mcp_openapi_proxy import server_fastmcp
+        spec = {
+            "openapi": "3.0.0",
+            "servers": [{"url": "https://dummy-base.com"}],
+            "paths": {
+                "/pet/findByTags": {
+                    "get": {
+                        "summary": "Finds Pets by tags.",
+                        "operationId": "findPetsByTags",
+                        "parameters": [
+                            {
+                                "name": "tags",
+                                "in": "query",
+                                "description": "Tags to filter by",
+                                "required": True,
+                                "schema": {"type": "array", "items": {"type": "string"}}
+                            },
+                            {
+                                "name": "ids",
+                                "in": "query",
+                                "required": False,
+                                "schema": {"type": "array"}
+                            }
+                        ],
+                        "responses": {"200": {"description": "OK"}}
+                    }
+                }
+            }
+        }
+        original_fetch = server_fastmcp.fetch_openapi_spec
+        server_fastmcp.fetch_openapi_spec = lambda url: spec
+        os.environ["OPENAPI_SPEC_URL"] = "http://dummy_url_issue16"
+        try:
+            result = json.loads(server_fastmcp.list_functions(env_key="OPENAPI_SPEC_URL"))
+        finally:
+            server_fastmcp.fetch_openapi_spec = original_fetch
+            os.environ.pop("OPENAPI_SPEC_URL", None)
+        tool = next(f for f in result if f.get("path") == "/pet/findByTags")
+        tags_prop = tool["inputSchema"]["properties"]["tags"]
+        self.assertEqual(tags_prop["type"], "array")
+        self.assertEqual(tags_prop.get("items"), {"type": "string"})
+        ids_prop = tool["inputSchema"]["properties"]["ids"]
+        self.assertEqual(ids_prop["type"], "array")
+        self.assertEqual(ids_prop.get("items"), {"type": "string"})
+
     def test_input_schema_contents(self):
         # Ensure that one tool is registered for the endpoint using the returned tools list directly
         registered_tools = register_functions(self.dummy_spec)


### PR DESCRIPTION
Fixes #16

OpenAI tool_use rejects generated tool schemas whose array properties lack an `items` schema (`array schema missing items`). The schema generation paths dropped `items` when converting OpenAPI parameters to JSON Schema.

## Changes
- **Low-level path (`mcp_openapi_proxy/openapi.py`, `register_functions`)**: array query/path parameters now copy `items` from the parameter schema, falling back to `{"type": "string"}` when the spec omits it. Array properties merged from `requestBody` object schemas get the same fallback.
- **FastMCP path (`mcp_openapi_proxy/server_fastmcp.py`, `list_functions`)**: parameter types are now read from the OpenAPI 3 `schema` object (with Swagger 2 param-level fallback), `array` is accepted as a type, and `items` is emitted with the same string fallback.

## Tests (TDD)
- 4 new tests in `tests/unit/test_input_schema_generation.py` covering: array param with items, array param without items (fallback), requestBody array properties (with and without items), and the FastMCP path. All confirmed failing before the fix.
- Full unit suite: 113 passed (was 109).

🤖 Generated with [Claude Code](https://claude.com/claude-code)