### PR TITLE
fix: respect TOOL_NAME_MAX_LENGTH without silently dropping tools

### DIFF
--- a/mcp_openapi_proxy/openapi.py
+++ b/mcp_openapi_proxy/openapi.py
@@ -123,11 +123,18 @@ def handle_auth(operation: Dict) -> Dict[str, str]:
     #       to potentially override or supplement env var based auth.
     return headers
 
+# Maps registered tool names to their operation details. Needed so that
+# names deduplicated after TOOL_NAME_MAX_LENGTH truncation (issue #11) can
+# still be resolved back to the right operation at call time.
+_REGISTERED_OPERATIONS: Dict[str, Dict] = {}
+
+
 def register_functions(spec: Dict) -> List[types.Tool]:
     """Register tools from OpenAPI spec."""
-    from .utils import is_tool_whitelisted # Keep import here to avoid circular dependency if utils imports openapi
+    from .utils import is_tool_whitelisted, deduplicate_tool_name # Keep import here to avoid circular dependency if utils imports openapi
 
     tools_list: List[types.Tool] = [] # Use a local list for registration
+    _REGISTERED_OPERATIONS.clear()
     logger.debug("Starting tool registration from OpenAPI spec.")
     if not spec:
         logger.error("OpenAPI spec is None or empty during registration.")
@@ -174,12 +181,17 @@ def register_functions(spec: Dict) -> List[types.Tool]:
                     continue # Skip this tool
 
                 # --- Check for duplicate names ---
+                # Truncation via TOOL_NAME_MAX_LENGTH can make distinct
+                # operations collide on the same name; rename instead of
+                # silently dropping the tool (issue #11).
                 if function_name in registered_names:
-                    logger.warning(
-                        f"Skipping registration for '{raw_name}': "
-                        f"Duplicate tool name '{function_name}' detected."
-                    )
-                    continue # Skip this tool
+                    function_name = deduplicate_tool_name(function_name, registered_names)
+                    if not re.match(TOOL_NAME_REGEX, function_name):
+                        logger.error(
+                            f"Skipping registration for '{raw_name}': "
+                            f"Deduplicated name '{function_name}' does not match required pattern '{TOOL_NAME_REGEX}'."
+                        )
+                        continue # Skip this tool
 
                 description = operation.get('summary', operation.get('description', 'No description available'))
                 # Ensure description is a string
@@ -277,6 +289,12 @@ def register_functions(spec: Dict) -> List[types.Tool]:
                 )
                 tools_list.append(tool)
                 registered_names.add(function_name)
+                _REGISTERED_OPERATIONS[function_name] = {
+                    "path": path,
+                    "method": method.upper(),
+                    "operation": operation,
+                    "original_path": path,
+                }
                 logger.debug(f"Registered tool: {function_name} from {raw_name}") # Simplified log
 
             except Exception as e:
@@ -297,6 +315,13 @@ def register_functions(spec: Dict) -> List[types.Tool]:
 
 def lookup_operation_details(function_name: str, spec: Dict) -> Union[Dict, None]:
     """Look up operation details from OpenAPI spec by function name."""
+    # Names registered via register_functions (including names deduplicated
+    # after TOOL_NAME_MAX_LENGTH truncation) are resolved from the registry,
+    # since they cannot be regenerated from the spec alone.
+    registered = _REGISTERED_OPERATIONS.get(function_name)
+    if registered:
+        return dict(registered)
+
     if not spec or 'paths' not in spec:
         logger.warning("Spec is missing or has no 'paths' key in lookup_operation_details.")
         return None

--- a/mcp_openapi_proxy/server_fastmcp.py
+++ b/mcp_openapi_proxy/server_fastmcp.py
@@ -19,7 +19,7 @@ from mcp import types
 from mcp.server.fastmcp import FastMCP
 from mcp_openapi_proxy.logging_setup import logger
 from mcp_openapi_proxy.openapi import fetch_openapi_spec, build_base_url, handle_auth
-from mcp_openapi_proxy.utils import is_tool_whitelisted, normalize_tool_name, strip_parameters, get_additional_headers
+from mcp_openapi_proxy.utils import is_tool_whitelisted, normalize_tool_name, strip_parameters, get_additional_headers, deduplicate_tool_name
 import sys
 
 # Logger is now configured in logging_setup.py, just use it
@@ -30,6 +30,11 @@ logger.debug(f"Server CWD: {os.getcwd()}")
 mcp = FastMCP("OpenApiProxy-Fast")
 
 spec = None  # Global spec for resources
+
+# Maps function names produced by list_functions to their operations, so that
+# names deduplicated after TOOL_NAME_MAX_LENGTH truncation (issue #11) remain
+# callable via call_function.
+_FUNCTION_OPERATIONS: Dict[str, Dict] = {}
 
 @mcp.tool()
 def list_functions(*, env_key: str = "OPENAPI_SPEC_URL") -> str:
@@ -74,6 +79,7 @@ def list_functions(*, env_key: str = "OPENAPI_SPEC_URL") -> str:
         logger.debug("No paths found in spec.")
         return json.dumps([])
     functions = {}
+    _FUNCTION_OPERATIONS.clear()
     for path, path_item in paths.items():
         logger.debug(f"Processing path: {path}")
         if not path_item:
@@ -96,8 +102,9 @@ def list_functions(*, env_key: str = "OPENAPI_SPEC_URL") -> str:
             raw_name = f"{method.upper()} {path}"
             function_name = normalize_tool_name(raw_name)
             if function_name in functions:
-                logger.debug(f"Skipping duplicate function name: {function_name}")
-                continue
+                # TOOL_NAME_MAX_LENGTH truncation can make distinct operations
+                # collide; rename instead of silently dropping (issue #11).
+                function_name = deduplicate_tool_name(function_name, functions)
             function_description = operation.get("summary", operation.get("description", "No description provided."))
             logger.debug(f"Registering function: {function_name} - {function_description}")
             input_schema = {
@@ -132,6 +139,11 @@ def list_functions(*, env_key: str = "OPENAPI_SPEC_URL") -> str:
                 "operationId": operation.get("operationId"),
                 "original_name": raw_name,
                 "inputSchema": input_schema
+            }
+            _FUNCTION_OPERATIONS[function_name] = {
+                "path": path,
+                "method": method.upper(),
+                "operation": operation
             }
     functions["list_resources"] = {
         "name": "list_resources",
@@ -236,11 +248,16 @@ def call_function(*, function_name: str, parameters: Optional[Dict] = None, env_
         logger.error("Spec is None for call_function")
         return json.dumps({"error": "Failed to fetch or parse the OpenAPI specification"})
     logger.debug(f"Spec keys for call_function: {list(spec.keys())}")
-    function_def = None
+    # Names recorded by list_functions (including names deduplicated after
+    # TOOL_NAME_MAX_LENGTH truncation, issue #11) cannot be regenerated from
+    # the spec alone, so consult the recorded mapping first.
+    function_def = dict(_FUNCTION_OPERATIONS[function_name]) if function_name in _FUNCTION_OPERATIONS else None
     paths = spec.get("paths", {})
     logger.debug(f"Paths for function lookup: {list(paths.keys())}")
-    
+
     for path, path_item in paths.items():
+        if function_def:
+            break
         logger.debug(f"Checking path: {path}")
         for method, operation in path_item.items():
             logger.debug(f"Checking method: {method} for path: {path}")

--- a/mcp_openapi_proxy/server_lowlevel.py
+++ b/mcp_openapi_proxy/server_lowlevel.py
@@ -468,6 +468,13 @@ async def get_prompt(request: types.GetPromptRequest) -> types.GetPromptResult:
 
 
 def lookup_operation_details(function_name: str, spec: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    # Resolve names recorded at registration time first: names deduplicated
+    # after TOOL_NAME_MAX_LENGTH truncation (issue #11) cannot be regenerated
+    # from the spec alone.
+    from mcp_openapi_proxy.openapi import _REGISTERED_OPERATIONS
+    registered = _REGISTERED_OPERATIONS.get(function_name)
+    if registered:
+        return dict(registered)
     if not spec or 'paths' not in spec:
         return None
     for path, path_item in spec['paths'].items():

--- a/mcp_openapi_proxy/utils.py
+++ b/mcp_openapi_proxy/utils.py
@@ -21,6 +21,59 @@ def setup_logging(debug: bool = False):
     from .logging_setup import setup_logging as ls
     return ls(debug)
 
+def get_tool_name_max_length() -> Optional[int]:
+    """Parse TOOL_NAME_MAX_LENGTH from the environment.
+
+    Returns a positive int, or None when unset/invalid (invalid values are
+    logged and ignored gracefully).
+    """
+    max_length_env = os.getenv("TOOL_NAME_MAX_LENGTH")
+    if max_length_env:
+        try:
+            parsed_max_length = int(max_length_env)
+            if parsed_max_length > 0:
+                return parsed_max_length
+            logger.warning(f"Invalid TOOL_NAME_MAX_LENGTH env var: {max_length_env}. Ignoring.")
+        except ValueError:
+            logger.warning(f"Invalid TOOL_NAME_MAX_LENGTH env var: {max_length_env}. Ignoring.")
+    return None
+
+
+def effective_tool_name_limit() -> int:
+    """The actual cap applied to tool names: TOOL_NAME_MAX_LENGTH bounded by
+    the 64-char protocol limit."""
+    custom = get_tool_name_max_length()
+    protocol_max = 64
+    return min(custom, protocol_max) if custom is not None else protocol_max
+
+
+def deduplicate_tool_name(tool_name: str, registered_names) -> str:
+    """Return a unique variant of tool_name that stays within the effective
+    length limit.
+
+    When TOOL_NAME_MAX_LENGTH truncation makes two endpoints collide on the
+    same name, the second must not be dropped (issue #11); it gets a short
+    numeric suffix instead, with the base truncated to keep within the limit.
+    """
+    if tool_name not in registered_names:
+        return tool_name
+    limit = effective_tool_name_limit()
+    counter = 2
+    while True:
+        suffix = f"_{counter}"
+        if len(tool_name) + len(suffix) <= limit:
+            candidate = f"{tool_name}{suffix}"
+        else:
+            candidate = f"{tool_name[:max(0, limit - len(suffix))]}{suffix}"
+        if candidate not in registered_names:
+            logger.warning(
+                f"Tool name collision for '{tool_name}' (TOOL_NAME_MAX_LENGTH truncation); "
+                f"renamed to '{candidate}'."
+            )
+            return candidate
+        counter += 1
+
+
 def normalize_tool_name(raw_name: str, max_length: Optional[int] = None) -> str:
     """
     Convert an HTTP method and path into a normalized tool name, applying length limits.
@@ -68,16 +121,7 @@ def normalize_tool_name(raw_name: str, max_length: Optional[int] = None) -> str:
         # Determine the effective custom max length based on env var and argument
         effective_max_length: Optional[int] = max_length
         if effective_max_length is None:
-            max_length_env = os.getenv("TOOL_NAME_MAX_LENGTH")
-            if max_length_env:
-                try:
-                    parsed_max_length = int(max_length_env)
-                    if parsed_max_length > 0:
-                        effective_max_length = parsed_max_length
-                    else:
-                        logger.warning(f"Invalid TOOL_NAME_MAX_LENGTH env var: {max_length_env}. Ignoring.")
-                except ValueError:
-                    logger.warning(f"Invalid TOOL_NAME_MAX_LENGTH env var: {max_length_env}. Ignoring.")
+            effective_max_length = get_tool_name_max_length()
 
         # Protocol limit
         PROTOCOL_MAX_LENGTH = 64

--- a/tests/unit/test_issue_11_tool_name_max_length.py
+++ b/tests/unit/test_issue_11_tool_name_max_length.py
@@ -1,0 +1,153 @@
+"""
+Regression tests for issue #11: TOOL_NAME_MAX_LENGTH not respected.
+
+https://github.com/matthewhand/mcp-openapi-proxy/issues/11
+
+The env var must be honoured everywhere tool names are produced:
+ - mcp_openapi_proxy.utils.normalize_tool_name (the shared helper)
+ - the low-level registration path (mcp_openapi_proxy.openapi.register_functions)
+ - the FastMCP path (mcp_openapi_proxy.server_fastmcp.list_functions)
+
+Invalid values ("abc", "-1", "0") must be ignored gracefully.
+
+Crucially, honouring a short limit must not silently drop endpoints: when
+truncation makes two distinct operations collide on the same name, both must
+still be registered (with unique names within the limit) and remain callable
+(lookup_operation_details must resolve the deduplicated names).
+"""
+
+import json
+
+import pytest
+
+from mcp_openapi_proxy import openapi, server_fastmcp, server_lowlevel
+from mcp_openapi_proxy.utils import normalize_tool_name
+
+
+def make_spec(paths):
+    return {
+        "openapi": "3.0.0",
+        "info": {"title": "test", "version": "1.0"},
+        "paths": paths,
+    }
+
+
+COLLIDING_SPEC = make_spec({
+    # Both normalize to "post_communication_n..." and collide when truncated
+    # to 20 chars.
+    "/communication/notification/email/send": {
+        "post": {"summary": "send", "responses": {}}
+    },
+    "/communication/notification/email/receive": {
+        "post": {"summary": "receive", "responses": {}}
+    },
+})
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("TOOL_NAME_PREFIX", raising=False)
+    monkeypatch.delenv("TOOL_NAME_MAX_LENGTH", raising=False)
+    monkeypatch.delenv("TOOL_WHITELIST", raising=False)
+
+
+def test_normalize_tool_name_respects_env_limit(monkeypatch):
+    monkeypatch.setenv("TOOL_NAME_MAX_LENGTH", "10")
+    name = normalize_tool_name("GET /some/very/long/path/that/keeps/going")
+    assert len(name) <= 10, f"normalize_tool_name ignored TOOL_NAME_MAX_LENGTH: {name!r}"
+
+
+def test_normalize_tool_name_env_limit_includes_prefix(monkeypatch):
+    # Issue #11 reporter used TOOL_NAME_PREFIX together with TOOL_NAME_MAX_LENGTH.
+    monkeypatch.setenv("TOOL_NAME_PREFIX", "otrs_")
+    monkeypatch.setenv("TOOL_NAME_MAX_LENGTH", "58")
+    name = normalize_tool_name(
+        "POST /communication/notification/event/transport/email/{NotificationID}/extra"
+    )
+    assert len(name) <= 58, f"prefixed name exceeds custom limit: {name!r}"
+    assert name.startswith("otrs_")
+
+
+@pytest.mark.parametrize("bad_value", ["abc", "-1", "0"])
+def test_invalid_env_values_ignored_gracefully(monkeypatch, bad_value):
+    monkeypatch.setenv("TOOL_NAME_MAX_LENGTH", bad_value)
+    # Must not raise, must not truncate below the protocol limit.
+    name = normalize_tool_name("GET /users/list")
+    assert name == "get_users_list"
+
+
+def test_register_functions_respects_env_limit(monkeypatch):
+    monkeypatch.setenv("TOOL_NAME_MAX_LENGTH", "10")
+    spec = make_spec({
+        "/services/{serviceId}/custom-domains/{customDomainIdOrName}/verify": {
+            "post": {"summary": "verify", "responses": {}}
+        },
+    })
+    tools = openapi.register_functions(spec)
+    assert tools, "expected at least one registered tool"
+    for tool in tools:
+        assert len(tool.name) <= 10, (
+            f"registration path ignored TOOL_NAME_MAX_LENGTH: {tool.name!r}"
+        )
+
+
+def test_register_functions_does_not_drop_tools_on_truncation_collision(monkeypatch):
+    """Honouring the limit must not silently drop colliding endpoints."""
+    monkeypatch.setenv("TOOL_NAME_MAX_LENGTH", "20")
+    tools = openapi.register_functions(COLLIDING_SPEC)
+    names = [t.name for t in tools]
+    assert len(names) == 2, (
+        f"expected both operations registered, got {names} - "
+        "truncation collision silently dropped a tool"
+    )
+    assert len(set(names)) == 2, f"tool names are not unique: {names}"
+    for name in names:
+        assert len(name) <= 20, f"deduplicated name exceeds limit: {name!r}"
+
+
+def test_lookup_resolves_deduplicated_names(monkeypatch):
+    """Every registered (deduplicated) name must remain callable via lookup."""
+    monkeypatch.setenv("TOOL_NAME_MAX_LENGTH", "20")
+    tools = openapi.register_functions(COLLIDING_SPEC)
+    assert len(tools) == 2
+    resolved_paths = set()
+    for tool in tools:
+        details = openapi.lookup_operation_details(tool.name, COLLIDING_SPEC)
+        assert details is not None, f"lookup failed for registered tool {tool.name!r}"
+        resolved_paths.add(details["path"])
+    assert resolved_paths == {
+        "/communication/notification/email/send",
+        "/communication/notification/email/receive",
+    }, f"lookup did not resolve each tool to its own operation: {resolved_paths}"
+
+
+def test_lowlevel_lookup_resolves_deduplicated_names(monkeypatch):
+    monkeypatch.setenv("TOOL_NAME_MAX_LENGTH", "20")
+    tools = openapi.register_functions(COLLIDING_SPEC)
+    assert len(tools) == 2
+    resolved_paths = set()
+    for tool in tools:
+        details = server_lowlevel.lookup_operation_details(tool.name, COLLIDING_SPEC)
+        assert details is not None, (
+            f"server_lowlevel lookup failed for registered tool {tool.name!r}"
+        )
+        resolved_paths.add(details["path"])
+    assert len(resolved_paths) == 2, (
+        f"server_lowlevel lookup did not resolve each tool to its own operation: {resolved_paths}"
+    )
+
+
+def test_fastmcp_list_functions_respects_env_limit(monkeypatch):
+    monkeypatch.setenv("TOOL_NAME_MAX_LENGTH", "20")
+    monkeypatch.setenv("OPENAPI_SPEC_URL", "http://dummy.example/spec.json")
+    monkeypatch.setattr(server_fastmcp, "fetch_openapi_spec", lambda url: COLLIDING_SPEC)
+    functions = json.loads(server_fastmcp.list_functions(env_key="OPENAPI_SPEC_URL"))
+    # Only consider functions derived from the spec (list_functions also
+    # returns built-in meta functions such as list_resources).
+    names = [f["name"] for f in functions if f.get("path") in COLLIDING_SPEC["paths"]]
+    for name in names:
+        assert len(name) <= 20, f"fastmcp path ignored TOOL_NAME_MAX_LENGTH: {name!r}"
+    assert len(names) == len(set(names)), f"fastmcp produced duplicate names: {names}"
+    assert len(names) == 2, (
+        f"fastmcp list_functions dropped a colliding tool: {names}"
+    )


### PR DESCRIPTION
Fixes #11

## Problem

`TOOL_NAME_MAX_LENGTH` truncation is applied in `normalize_tool_name`, but when truncation makes two distinct endpoints collide on the same name, registration silently skipped all but the first tool. Setting the env var (as the issue reporter did with `TOOL_NAME_MAX_LENGTH=58` against an OTRS spec with many long, similarly-prefixed paths) therefore lost tools — and any deduplicated name could not be resolved back to its operation at call time.

## Changes

- **utils.py**: extracted `get_tool_name_max_length()` (invalid values like `abc`, `-1`, `0` are still logged and ignored gracefully) and added `deduplicate_tool_name()`, which renames collisions with a numeric suffix while keeping names within the effective limit (custom limit bounded by the 64-char protocol limit).
- **openapi.py**: `register_functions` renames colliding tools instead of dropping them and records a name → operation registry; `lookup_operation_details` consults the registry first, since deduplicated names cannot be regenerated from the spec alone.
- **server_lowlevel.py**: its `lookup_operation_details` also consults the registry first.
- **server_fastmcp.py**: `list_functions` applies the same dedup instead of skipping, and `call_function` resolves recorded names before falling back to spec regeneration.

## Tests (TDD)

New `tests/unit/test_issue_11_tool_name_max_length.py` (10 tests): env limit respected from `normalize_tool_name`, the low-level registration path, and the fastmcp path (with and without `TOOL_NAME_PREFIX`); invalid values ignored gracefully; truncation collisions keep all tools registered with unique in-limit names; and both lookup implementations resolve deduplicated names to the correct operations. The collision/lookup/fastmcp tests failed before the fix.

Full unit suite: 119 passed (109 pre-existing + 10 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)