### PR TITLE
docs(wordpress): document example + showcase live blog + DELETE lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Full environment-variable reference is in [Environment Variables](#environment-v
 - [Environment Variables](#environment-variables)
 - [Verified Clients & Live Results (2026-06-12)](#verified-clients--live-results-2026-06-12)
   - [Tips](#tips)
-- [Examples](#examples) — Glama, Fly.io, Render, Slack, GetZep, Virustotal, Notion, Asana, APIs.guru, NetBox, Box, WolframAlpha (collapsed)
+- [Examples](#examples) — Glama, Fly.io, Render, Slack, GetZep, Virustotal, Notion, Asana, APIs.guru, NetBox, Box, WolframAlpha, WordPress (collapsed)
 - [Troubleshooting](#troubleshooting)
 - [License](#license)
 
@@ -857,6 +857,43 @@ Letta runs agents on a server, so attachment differs by deployment:
 - **Letta Cloud** rejects stdio and needs a **remote streamable-HTTP** MCP URL behind authentication.
 
 Both were verified live (an agent autonomously called `get_v1_attributes` from the Glama spec through the proxy). Full setup for both paths, including the supergateway wrapper and the security note for the Cloud endpoint, is in [`examples/letta/README.md`](examples/letta/README.md).
+
+</details>
+
+<details>
+<summary><b>WordPress Example</b> — publish to a real WordPress blog from any MCP agent</summary>
+
+This example turns the WordPress REST API into MCP tools so an agent can **create, read, update, and trash blog posts**. It is the example behind a real-world demonstration: a fleet of agent CLIs published to the live blog at **[matthewhand.mywebcommunity.org](https://matthewhand.mywebcommunity.org/)** through this proxy — see the write-up [*“Turning Any API into Agent Tools”*](https://matthewhand.mywebcommunity.org/2026/06/12/turning-any-api-into-agent-tools-a-real-world-test-of-mcp-openapi-proxy/), itself posted via the proxy.
+
+Example config — `examples/wordpress-claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "wordpress": {
+      "command": "uvx",
+      "args": ["mcp-openapi-proxy"],
+      "env": {
+        "OPENAPI_SPEC_URL": "https://raw.githubusercontent.com/matthewhand/mcp-openapi-proxy/main/examples/wordpress-openapi.json",
+        "SERVER_URL_OVERRIDE": "https://your-site.example.com/wp-json",
+        "EXTRA_HEADERS": "Authorization: Basic BASE64_OF_USERNAME_COLON_APPLICATION_PASSWORD",
+        "IGNORE_SSL_TOOLS": "false",
+        "TOOL_WHITELIST": "/wp/v2/posts"
+      }
+    }
+  }
+}
+```
+
+Exposed tools (from the bundled `examples/wordpress-openapi.json`): `get_wp_v2_posts`, `post_wp_v2_posts` (create), `get_wp_v2_posts_by_id`, `post_wp_v2_posts_by_id` (update), and `delete_wp_v2_posts_by_id` (trash) — the full post lifecycle.
+
+**Auth — use a WordPress *Application Password*, not your login password.** WordPress REST rejects login passwords for Basic auth. In `wp-admin → Users → (your user) → Application Passwords`, create one, then base64-encode `username:application-password` for the `EXTRA_HEADERS` value:
+
+```bash
+printf 'myuser:xxxx xxxx xxxx xxxx xxxx xxxx' | base64 -w0
+```
+
+Tips: set `IGNORE_SSL_TOOLS=true` only if your host serves a self-signed/mismatched cert; give each agent its own (revocable) application password; keep `TOOL_WHITELIST=/wp/v2/posts` so the agent can touch only posts.
 
 </details>
 

--- a/examples/wordpress-claude_desktop_config.json
+++ b/examples/wordpress-claude_desktop_config.json
@@ -1,15 +1,17 @@
 {
-    "mcpServers": {
-        "wordpress": {
-            "command": "uvx",
-            "args": ["mcp-openapi-proxy"],
-            "env": {
-                "OPENAPI_SPEC_URL": "https://raw.githubusercontent.com/matthewhand/mcp-openapi-proxy/main/examples/wordpress-openapi.json",
-                "SERVER_URL_OVERRIDE": "https://your-site.example.com/wp-json",
-                "EXTRA_HEADERS": "Authorization: Basic BASE64_OF_USERNAME_COLON_APPLICATION_PASSWORD",
-                "IGNORE_SSL_TOOLS": "false",
-                "TOOL_WHITELIST": "/wp/v2/posts"
-            }
-        }
+  "mcpServers": {
+    "wordpress": {
+      "command": "uvx",
+      "args": [
+        "mcp-openapi-proxy"
+      ],
+      "env": {
+        "OPENAPI_SPEC_URL": "https://raw.githubusercontent.com/matthewhand/mcp-openapi-proxy/main/examples/wordpress-openapi.json",
+        "SERVER_URL_OVERRIDE": "https://your-site.example.com/wp-json",
+        "EXTRA_HEADERS": "Authorization: Basic BASE64_OF_USERNAME_COLON_APPLICATION_PASSWORD",
+        "IGNORE_SSL_TOOLS": "false",
+        "TOOL_WHITELIST": "/wp/v2/posts"
+      }
     }
+  }
 }

--- a/examples/wordpress-openapi.json
+++ b/examples/wordpress-openapi.json
@@ -6,7 +6,10 @@
     "description": "Minimal spec exposing WordPress posts list/create/update via mcp-openapi-proxy"
   },
   "servers": [
-    { "url": "https://YOUR-WORDPRESS-SITE/wp-json", "description": "Placeholder - set SERVER_URL_OVERRIDE env var to your site's /wp-json base" }
+    {
+      "url": "https://YOUR-WORDPRESS-SITE/wp-json",
+      "description": "Placeholder - set SERVER_URL_OVERRIDE env var to your site's /wp-json base"
+    }
   ],
   "paths": {
     "/wp/v2/posts": {
@@ -14,12 +17,40 @@
         "operationId": "list_posts",
         "summary": "List posts",
         "parameters": [
-          { "name": "per_page", "in": "query", "schema": { "type": "integer" } },
-          { "name": "page", "in": "query", "schema": { "type": "integer" } },
-          { "name": "search", "in": "query", "schema": { "type": "string" } },
-          { "name": "status", "in": "query", "schema": { "type": "string" } }
+          {
+            "name": "per_page",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
-        "responses": { "200": { "description": "Array of posts" } }
+        "responses": {
+          "200": {
+            "description": "Array of posts"
+          }
+        }
       },
       "post": {
         "operationId": "create_post",
@@ -31,17 +62,38 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "title": { "type": "string" },
-                  "content": { "type": "string" },
-                  "status": { "type": "string", "enum": ["draft", "publish", "pending", "private"] },
-                  "excerpt": { "type": "string" }
+                  "title": {
+                    "type": "string"
+                  },
+                  "content": {
+                    "type": "string"
+                  },
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "draft",
+                      "publish",
+                      "pending",
+                      "private"
+                    ]
+                  },
+                  "excerpt": {
+                    "type": "string"
+                  }
                 },
-                "required": ["title", "content"]
+                "required": [
+                  "title",
+                  "content"
+                ]
               }
             }
           }
         },
-        "responses": { "201": { "description": "Created post" } }
+        "responses": {
+          "201": {
+            "description": "Created post"
+          }
+        }
       }
     },
     "/wp/v2/posts/{id}": {
@@ -49,15 +101,33 @@
         "operationId": "get_post",
         "summary": "Get a single post",
         "parameters": [
-          { "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
         ],
-        "responses": { "200": { "description": "Post" } }
+        "responses": {
+          "200": {
+            "description": "Post"
+          }
+        }
       },
       "post": {
         "operationId": "update_post",
         "summary": "Update a post (WP accepts POST for updates)",
         "parameters": [
-          { "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
         ],
         "requestBody": {
           "required": false,
@@ -66,15 +136,54 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "title": { "type": "string" },
-                  "content": { "type": "string" },
-                  "status": { "type": "string" }
+                  "title": {
+                    "type": "string"
+                  },
+                  "content": {
+                    "type": "string"
+                  },
+                  "status": {
+                    "type": "string"
+                  }
                 }
               }
             }
           }
         },
-        "responses": { "200": { "description": "Updated post" } }
+        "responses": {
+          "200": {
+            "description": "Updated post"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Trash or delete a post",
+        "operationId": "deletePost",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Post ID"
+          },
+          {
+            "name": "force",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "Whether to bypass Trash and permanently delete."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The trashed/deleted post object"
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes #49

- Adds the missing WordPress example section to the README (collapsible + TOC), featuring the real-world demo at [matthewhand.mywebcommunity.org](https://matthewhand.mywebcommunity.org/) and the post published through the proxy. Auth stays a placeholder; includes the application-password best-practice note.
- Extends `examples/wordpress-openapi.json` with `DELETE /wp/v2/posts/{id}` → full create/read/update/trash lifecycle is now MCP-drivable (verified the create+read path live via `uvx mcp-openapi-proxy` stdio).

Docs/example only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)