### PR TITLE
docs: drop agy headless caveat from README summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 - ✅ **Codex**, **Gemini**, **Qwen**, **Kilocode**, **opencode** — native tool calls over stdio
 - ✅ **Vibe** — native discovery and read calls (writes were CLI-flaky, not a proxy issue)
 - ✅ **Letta** — Cloud (via a remote streamable-HTTP MCP URL) and self-hosted (via stdio)
-- ⚠️ **agy** — could not attach in headless mode; MCP tool enablement is interactive-only in agy (an agy limitation, not the proxy)
 
 See the [client matrix](#client-matrix) for attach mechanisms, models, and exact results.
 


### PR DESCRIPTION
Removes the agy headless-mode warning bullet from the README intro list, as requested.

Note: two other agy references remain (client-matrix row and prose in the attach-mechanism section) — left intact pending a decision on whether the matrix should keep recording the agy result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)