### PR TITLE
fix(yaml): datetime specs (apis.guru) no longer crash — 0.2.1

### DIFF
--- a/mcp_openapi_proxy/server_lowlevel.py
+++ b/mcp_openapi_proxy/server_lowlevel.py
@@ -408,7 +408,7 @@ async def read_resource(request: types.ReadResourceRequest) -> types.ReadResourc
                 ]
             )
         logger.debug("Dumping spec to JSON...")
-        spec_json = json.dumps(spec_data, indent=2)
+        spec_json = json.dumps(spec_data, indent=2, default=str)
         logger.debug(f"Forcing spec JSON return: {spec_json[:50]}...")
         return types.ReadResourceResult(
             contents=[

--- a/mcp_openapi_proxy/utils.py
+++ b/mcp_openapi_proxy/utils.py
@@ -14,6 +14,28 @@ from mcp import types
 # Import the configured logger
 from .logging_setup import logger
 
+
+class _NoTimestampSafeLoader(yaml.SafeLoader):
+    """SafeLoader that keeps unquoted RFC3339 timestamps as plain strings.
+
+    PyYAML's SafeLoader auto-converts values like ``2015-02-22T20:00:45.000Z``
+    into Python ``datetime`` objects. Such objects are not JSON-serializable,
+    which crashed spec caching and ``resources/read`` for specs that carry
+    datetime example values (e.g. the apis.guru directory spec). Loading specs
+    with this loader keeps every scalar JSON-safe.
+    """
+
+
+_NoTimestampSafeLoader.yaml_implicit_resolvers = {
+    key: [(tag, regexp) for tag, regexp in resolvers if tag != "tag:yaml.org,2002:timestamp"]
+    for key, resolvers in yaml.SafeLoader.yaml_implicit_resolvers.items()
+}
+
+
+def yaml_load_safe(content: str):
+    """Parse YAML with timestamps preserved as strings (JSON-safe)."""
+    return yaml.load(content, Loader=_NoTimestampSafeLoader)
+
 def setup_logging(debug: bool = False):
     """
     Configure logging for the application.
@@ -196,7 +218,7 @@ def _spec_cache_store(url: str, spec: Dict) -> None:
     try:
         path = _spec_cache_path(url)
         with open(path + ".tmp", "w") as f:
-            json.dump(spec, f)
+            json.dump(spec, f, default=str)
         os.replace(path + ".tmp", path)
         logger.debug(f"Cached spec for {url} at {path}")
     except OSError as exc:
@@ -226,7 +248,7 @@ def fetch_openapi_spec(url: str, retries: int = 3) -> Optional[Dict]:
                 logger.debug(f"Using {spec_format.upper()} parser based on OPENAPI_SPEC_FORMAT env var")
                 if spec_format == "yaml":
                     try:
-                        spec = yaml.safe_load(content)
+                        spec = yaml_load_safe(content)
                         logger.debug(f"Parsed as YAML from {url}")
                     except yaml.YAMLError as ye:
                         logger.error(f"YAML parsing failed: {ye}. Raw content: {content[:500]}...")
@@ -252,7 +274,7 @@ def fetch_openapi_spec(url: str, retries: int = 3) -> Optional[Dict]:
                     logger.debug(f"Parsed as JSON from {url}")
                 except json.JSONDecodeError:
                     try:
-                        spec = yaml.safe_load(content)
+                        spec = yaml_load_safe(content)
                         logger.debug(f"Parsed as YAML from {url}")
                     except yaml.YAMLError as ye:
                         logger.error(f"YAML parsing failed: {ye}. Raw content: {content[:500]}...")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "mcp-openapi-proxy"
 requires-python = ">=3.10"
-version = "0.2.0"
+version = "0.2.1"
 description = "MCP server for exposing OpenAPI specifications as MCP tools."
 readme = "README.md"
 authors = [

--- a/tests/unit/test_yaml_datetime_serialization.py
+++ b/tests/unit/test_yaml_datetime_serialization.py
@@ -1,0 +1,52 @@
+"""Regression (issue #52): YAML specs with unquoted datetime example values
+must not produce non-JSON-serializable datetime objects."""
+import datetime
+import json
+import os
+
+import yaml
+
+
+def test_yaml_load_safe_keeps_timestamp_as_string():
+    from mcp_openapi_proxy.utils import yaml_load_safe
+    data = yaml_load_safe("when: 2015-02-22T20:00:45.000Z\n")
+    assert isinstance(data["when"], str)
+    # plain SafeLoader would have produced a datetime — prove the difference
+    assert isinstance(yaml.safe_load("when: 2015-02-22T20:00:45.000Z\n")["when"],
+                      datetime.datetime)
+
+
+def test_fetch_yaml_spec_with_datetime_is_json_serializable(tmp_path, monkeypatch):
+    from mcp_openapi_proxy.utils import fetch_openapi_spec
+    spec = (
+        "openapi: 3.0.0\n"
+        "info: {title: dt, version: 1.0.0}\n"
+        "paths:\n"
+        "  /x:\n"
+        "    get:\n"
+        "      responses:\n"
+        "        '200':\n"
+        "          description: ok\n"
+        "          content:\n"
+        "            application/json:\n"
+        "              example: {created: 2015-02-22T20:00:45.000Z}\n"
+    )
+    f = tmp_path / "spec.yaml"
+    f.write_text(spec)
+    monkeypatch.setenv("OPENAPI_SPEC_FORMAT", "yaml")
+    monkeypatch.setenv("OPENAPI_SPEC_CACHE_TTL_SECONDS", "0")
+    parsed = fetch_openapi_spec(f"file://{f}")
+    assert parsed is not None
+    # the whole spec must be JSON-serializable (this is what crashed before)
+    json.dumps(parsed)
+    assert parsed["paths"]["/x"]["get"]["responses"]["200"]["content"]["application/json"]["example"]["created"] == "2015-02-22T20:00:45.000Z"
+
+
+def test_spec_cache_store_handles_remaining_nonstring(tmp_path, monkeypatch):
+    """default=str safety net: caching never crashes even on odd scalars."""
+    from mcp_openapi_proxy import utils
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    monkeypatch.setenv("OPENAPI_SPEC_CACHE_TTL_SECONDS", "3600")
+    url = "http://example.invalid/s.json"
+    utils._spec_cache_store(url, {"d": datetime.datetime(2020, 1, 1)})  # must not raise
+    assert utils._spec_cache_load(url) is not None

--- a/uv.lock
+++ b/uv.lock
@@ -407,7 +407,7 @@ cli = [
 
 [[package]]
 name = "mcp-openapi-proxy"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Fixes #52

0.2.0 regression: the spec cache (#40) `json.dump`s the spec; PyYAML turns unquoted RFC3339 datetimes into `datetime` objects → `not JSON serializable` → 0 tools. Broke apis.guru (a credential-free example).

Fix: load YAML with a SafeLoader that drops the timestamp resolver (timestamps stay strings), plus `default=str` safety nets. 3 regression tests; **138 pass**. Live: apis.guru 0 → 7 tools.

Version 0.2.0 → **0.2.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)