### PR TITLE
Advertise prompts & resources by default; correct client matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+## 0.3.0
+
+### Changed
+- **Prompts and resources are now advertised by default.** `ENABLE_PROMPTS` and
+  `ENABLE_RESOURCES` default to `true`. Previously they defaulted to `false`, which —
+  per the MCP spec (a client won't call `prompts/list`/`resources/list` unless the
+  capability is advertised in `initialize`) — made prompts and resources **invisible to
+  every client at once**, despite being implemented and served correctly. Opt out with
+  `ENABLE_PROMPTS=false` / `ENABLE_RESOURCES=false`.
+
+### Added
+- Regression test asserting the **default** handshake (no env flags) advertises prompts
+  and resources, not just tools.
+
+### Docs
+- Corrected the client matrix in `README.md` and `docs/verification-case-study.md`.
+  Re-verified the real client binaries with advertising enabled: **Qwen** surfaces
+  prompts (slash commands), **Kilocode** surfaces resources (`access_mcp_resource`),
+  Gemini exposes prompts interactively only, Vibe is tools-only. **All pre-fix
+  prompt/resource findings are voided** (they were measured while advertising defaulted
+  off); Codex, opencode, and Letta are marked **unknown** pending re-test. Tool-call
+  results were unaffected and stand.
+
+## 0.2.1
+
+- See the [verification case study](docs/verification-case-study.md) for the 0.2.0/0.2.1
+  multi-client, multi-API verification sweep and the defects fixed.

--- a/README.md
+++ b/README.md
@@ -153,27 +153,27 @@ The example configurations below were exercised against the live APIs, and the p
 
 | Agent CLI | Model used (live test) | MCP attach mechanism | Tool calls | Prompts/Resources surfaced to model? |
 |---|---|---|---|---|
-| Codex | `gpt-5-codex` (OpenAI API) | `codex exec -c mcp_servers.*` | ✅ native | ❌ (used raw stdio) |
-| Gemini | Google OAuth free tier (CLI default model) | project `.gemini/settings.json` `mcpServers` | ✅ native | ❌ interactive slash-commands only |
-| Qwen | `agent` group via local LiteLLM gateway | project `.qwen/settings.json` | ✅ native | ⚠️ prompts ✅ (slash cmds `/summarize_spec`); resources ❌ † |
-| Kilocode | `kilo-auto/free` | global `settings/mcp_settings.json`, clean workspace | ✅ native | ⚠️ resources ✅ (`access_mcp_resource`); prompts ❌ † |
-| opencode | `orchestration` group via local LiteLLM gateway | `~/.config/opencode/opencode.json` `mcp` | ✅ native | ❌ |
-| Vibe | `mistral-medium-3.5` | `~/.vibe/config.toml` `[[mcp_servers]]` | ✅ discovery + reads (writes flaky) | ❌ |
-| agy | — | — | ❌ headless cannot enable MCP | — |
-| letta cloud | Letta Cloud default | streamable-HTTP MCP URL (`/mcp add --transport http` + bearer) | ✅ remote (stdio rejected) | — |
-| letta (self-hosted ≤0.11.x) | `agent` group via local LiteLLM gateway | stdio via `PUT /v1/tools/mcp/servers` | ✅ native | — |
+| Codex | `gpt-5-codex` (OpenAI API) | `codex exec -c mcp_servers.*` | ✅ native | unknown ‡ |
+| Gemini | Google OAuth free tier (CLI default model) | project `.gemini/settings.json` `mcpServers` | ✅ native | prompts: interactive slash only · resources: ❌ † |
+| Qwen | `agent` group via local LiteLLM gateway | project `.qwen/settings.json` | ✅ native | prompts: ✅ (slash `/summarize_spec`) · resources: ❌ † |
+| Kilocode | `kilo-auto/free` | global `settings/mcp_settings.json`, clean workspace | ✅ native | prompts: ❌ · resources: ✅ (`access_mcp_resource`) † |
+| opencode | `orchestration` group via local LiteLLM gateway | `~/.config/opencode/opencode.json` `mcp` | ✅ native | unknown ‡ |
+| Vibe | `mistral-medium-3.5` | `~/.vibe/config.toml` `[[mcp_servers]]` | ✅ discovery + reads (writes flaky) | prompts: ❌ · resources: ❌ (tools-only) † |
+| agy | — | — | ❌ headless cannot enable MCP | n/a |
+| letta cloud | Letta Cloud default | streamable-HTTP MCP URL (`/mcp add --transport http` + bearer) | ✅ remote (stdio rejected) | unknown ‡ |
+| letta (self-hosted ≤0.11.x) | `agent` group via local LiteLLM gateway | stdio via `PUT /v1/tools/mcp/servers` | ✅ native | unknown ‡ |
 
-> **† Re-verified 2026-06-14 with capability advertising enabled.** The original
-> sweep ran before prompts/resources were advertised **by default** — the server
-> only advertised them when `ENABLE_PROMPTS`/`ENABLE_RESOURCES` were set, so most
-> rows above recorded "client can't see them" when in fact the *server* wasn't
-> advertising. That default is now **on** (this release). Re-testing the real
-> binaries with advertising enabled shows support is genuine but **uneven**:
-> **tools** work everywhere; **prompts** reach the model on Qwen (slash commands)
-> and Gemini (interactive only); **resources** reach the model on Kilocode. The
-> remaining ❌ are real client-side gaps, not a proxy limitation (the proxy
-> advertises and serves both — verified over raw stdio). Codex, opencode, and
-> Letta were not re-run in the 2026-06-14 pass.
+> **Prompts/resources column — read this.** The original 0.2.0 sweep ran while the
+> server advertised prompts/resources **only when `ENABLE_PROMPTS`/`ENABLE_RESOURCES`
+> were set — they defaulted OFF.** Per the MCP spec a client won't call
+> `prompts/list`/`resources/list` unless the capability is advertised, so those early
+> results measured the *server's* default, not the clients. **All prior prompt/resource
+> findings are therefore voided.** This release defaults advertising **on**.
+>
+> - **† re-verified 2026-06-14** with advertising on, against the real client binary. Genuine, uneven: **tools** everywhere; **prompts→model** Qwen (slash) & Gemini (interactive only); **resources→model** Kilocode. Vibe is tools-only (confirmed in source).
+> - **‡ unknown** — not yet re-tested under advertising-on (opencode not installed here; Letta needs a running server + gateway; Codex parked). Prior ❌ values are not carried forward.
+>
+> Tool-calling (the `Tool calls` column) was unaffected by the advertising default and stands as originally verified.
 
 Minimal sanitized configs per client (the no-auth Glama spec is used as the smallest working example; substitute your own spec URL and `$YOUR_KEY` as needed):
 

--- a/README.md
+++ b/README.md
@@ -155,13 +155,25 @@ The example configurations below were exercised against the live APIs, and the p
 |---|---|---|---|---|
 | Codex | `gpt-5-codex` (OpenAI API) | `codex exec -c mcp_servers.*` | ✅ native | ❌ (used raw stdio) |
 | Gemini | Google OAuth free tier (CLI default model) | project `.gemini/settings.json` `mcpServers` | ✅ native | ❌ interactive slash-commands only |
-| Qwen | `agent` group via local LiteLLM gateway | project `.qwen/settings.json` | ✅ native | ❌ NO_PROMPT_ACCESS |
-| Kilocode | `kilo-auto/free` | global `settings/mcp_settings.json`, clean workspace | ✅ native | ❌ |
+| Qwen | `agent` group via local LiteLLM gateway | project `.qwen/settings.json` | ✅ native | ⚠️ prompts ✅ (slash cmds `/summarize_spec`); resources ❌ † |
+| Kilocode | `kilo-auto/free` | global `settings/mcp_settings.json`, clean workspace | ✅ native | ⚠️ resources ✅ (`access_mcp_resource`); prompts ❌ † |
 | opencode | `orchestration` group via local LiteLLM gateway | `~/.config/opencode/opencode.json` `mcp` | ✅ native | ❌ |
 | Vibe | `mistral-medium-3.5` | `~/.vibe/config.toml` `[[mcp_servers]]` | ✅ discovery + reads (writes flaky) | ❌ |
 | agy | — | — | ❌ headless cannot enable MCP | — |
 | letta cloud | Letta Cloud default | streamable-HTTP MCP URL (`/mcp add --transport http` + bearer) | ✅ remote (stdio rejected) | — |
 | letta (self-hosted ≤0.11.x) | `agent` group via local LiteLLM gateway | stdio via `PUT /v1/tools/mcp/servers` | ✅ native | — |
+
+> **† Re-verified 2026-06-14 with capability advertising enabled.** The original
+> sweep ran before prompts/resources were advertised **by default** — the server
+> only advertised them when `ENABLE_PROMPTS`/`ENABLE_RESOURCES` were set, so most
+> rows above recorded "client can't see them" when in fact the *server* wasn't
+> advertising. That default is now **on** (this release). Re-testing the real
+> binaries with advertising enabled shows support is genuine but **uneven**:
+> **tools** work everywhere; **prompts** reach the model on Qwen (slash commands)
+> and Gemini (interactive only); **resources** reach the model on Kilocode. The
+> remaining ❌ are real client-side gaps, not a proxy limitation (the proxy
+> advertises and serves both — verified over raw stdio). Codex, opencode, and
+> Letta were not re-run in the 2026-06-14 pass.
 
 Minimal sanitized configs per client (the no-auth Glama spec is used as the smallest working example; substitute your own spec URL and `$YOUR_KEY` as needed):
 

--- a/docs/verification-case-study.md
+++ b/docs/verification-case-study.md
@@ -49,15 +49,17 @@ sane tool count.
 
 | Client | Model (live test) | MCP attach mechanism | Tool calls | Prompts/resources to model |
 | --- | --- | --- | --- | --- |
-| Codex | gpt-5-codex | `codex exec -c mcp_servers.*` | ✅ native | ❌ (raw stdio only) |
-| Gemini | Google OAuth tier | project `.gemini/settings.json` | ✅ native | ❌ interactive slash-commands only |
-| Qwen | gateway model group | project `.qwen/settings.json` | ✅ native | ⚠️ prompts ✅ (slash cmds); resources ❌ † |
-| Kilocode | free auto model | global `mcp_settings.json` | ✅ native | ⚠️ resources ✅ (`access_mcp_resource`); prompts ❌ † |
-| opencode | gateway model group | `opencode.json` `mcp` | ✅ native | ❌ |
-| Vibe | mistral-medium-3.5 | `~/.vibe/config.toml` `[[mcp_servers]]` | ✅ discovery + reads | ❌ |
-| agy | — | — | ❌ headless can't enable MCP | — |
-| Letta (self-hosted) | gateway model group | stdio via `PUT /v1/tools/mcp/servers` | ✅ native | — |
-| Letta Cloud | Letta default | remote streamable-HTTP MCP URL | ✅ (stdio rejected) | — |
+| Codex | gpt-5-codex | `codex exec -c mcp_servers.*` | ✅ native | unknown ‡ |
+| Gemini | Google OAuth tier | project `.gemini/settings.json` | ✅ native | prompts: interactive slash only · resources: ❌ † |
+| Qwen | gateway model group | project `.qwen/settings.json` | ✅ native | prompts: ✅ (slash) · resources: ❌ † |
+| Kilocode | free auto model | global `mcp_settings.json` | ✅ native | prompts: ❌ · resources: ✅ (`access_mcp_resource`) † |
+| opencode | gateway model group | `opencode.json` `mcp` | ✅ native | unknown ‡ |
+| Vibe | mistral-medium-3.5 | `~/.vibe/config.toml` `[[mcp_servers]]` | ✅ discovery + reads | prompts: ❌ · resources: ❌ (tools-only) † |
+| agy | — | — | ❌ headless can't enable MCP | n/a |
+| Letta (self-hosted) | gateway model group | stdio via `PUT /v1/tools/mcp/servers` | ✅ native | unknown ‡ |
+| Letta Cloud | Letta default | remote streamable-HTTP MCP URL | ✅ (stdio rejected) | unknown ‡ |
+
+*† re-verified 2026-06-14 with advertising on (real binary). ‡ not yet re-tested under advertising-on — prior 0.2.0 prompt/resource results are **voided** (they were measured while the server defaulted to advertising neither). Tool-call results were unaffected and stand.*
 
 **Systemic finding:** every CLI tested could call MCP *tools* natively. Surfacing of
 MCP *prompts/resources* to the model is uneven across clients — but read the correction

--- a/docs/verification-case-study.md
+++ b/docs/verification-case-study.md
@@ -51,19 +51,31 @@ sane tool count.
 | --- | --- | --- | --- | --- |
 | Codex | gpt-5-codex | `codex exec -c mcp_servers.*` | ✅ native | ❌ (raw stdio only) |
 | Gemini | Google OAuth tier | project `.gemini/settings.json` | ✅ native | ❌ interactive slash-commands only |
-| Qwen | gateway model group | project `.qwen/settings.json` | ✅ native | ❌ no model access |
-| Kilocode | free auto model | global `mcp_settings.json` | ✅ native | ❌ |
+| Qwen | gateway model group | project `.qwen/settings.json` | ✅ native | ⚠️ prompts ✅ (slash cmds); resources ❌ † |
+| Kilocode | free auto model | global `mcp_settings.json` | ✅ native | ⚠️ resources ✅ (`access_mcp_resource`); prompts ❌ † |
 | opencode | gateway model group | `opencode.json` `mcp` | ✅ native | ❌ |
 | Vibe | mistral-medium-3.5 | `~/.vibe/config.toml` `[[mcp_servers]]` | ✅ discovery + reads | ❌ |
 | agy | — | — | ❌ headless can't enable MCP | — |
 | Letta (self-hosted) | gateway model group | stdio via `PUT /v1/tools/mcp/servers` | ✅ native | — |
 | Letta Cloud | Letta default | remote streamable-HTTP MCP URL | ✅ (stdio rejected) | — |
 
-**Systemic finding:** every CLI tested could call MCP *tools* natively, but **none surfaced
-MCP *prompts/resources* to the model** non-interactively (Gemini exposes them as slash
-commands; others not at all). Prompts/resources were therefore verified over raw stdio
-JSON-RPC. This is a client-ecosystem gap, not a proxy limitation — the proxy advertises and
-serves both correctly.
+**Systemic finding:** every CLI tested could call MCP *tools* natively. Surfacing of
+MCP *prompts/resources* to the model is uneven across clients — but read the correction
+below before concluding it's purely a client gap.
+
+> **† Correction (2026-06-14).** This original sweep ran against a build where the
+> low-level server advertised prompts/resources **only when `ENABLE_PROMPTS`/`ENABLE_RESOURCES`
+> were explicitly set — they defaulted OFF.** Per the MCP spec, a client will not call
+> `prompts/list`/`resources/list` unless the capability is advertised in `initialize`, so
+> a server that doesn't advertise makes prompts/resources invisible to **every** client at
+> once. Part of the original "client-ecosystem gap" was therefore the proxy's own default,
+> not the clients. That default is now **on** (advertising by default; opt out with
+> `ENABLE_PROMPTS=false`/`ENABLE_RESOURCES=false`). Re-running the **real** client binaries
+> with advertising enabled: **tools** universal; **prompts→model** on Qwen (slash commands)
+> and Gemini (interactive only); **resources→model** on Kilocode (`access_mcp_resource`).
+> Vibe remains tools-only (no prompt/resource client support — confirmed in source); Codex,
+> opencode, and Letta were not re-run in this pass. So the residual gap is real and
+> client-side, but **not universal** — and the proxy serves both correctly once it advertises.
 
 ## Prompts & resources
 
@@ -80,6 +92,7 @@ The sweep surfaced real defects; each was reproduced, fixed with tests, and rele
 | Issue | Defect | Resolution |
 | --- | --- | --- |
 | #23 | Strict clients saw **zero tools** — empty capabilities + a crash in resource discovery | PR #22 + stdio-handshake test harness |
+| follow-up | Prompts/resources advertised **only when `ENABLE_*` set (default OFF)** → invisible to every client; the sweep mis-attributed this to a client gap | default `ENABLE_PROMPTS`/`ENABLE_RESOURCES` to **on** + regression test asserting default advertisement |
 | #14 | `IGNORE_SSL_TOOLS` ignored by the low-level dispatcher | PR #21 (groundwork by @robbycochran, #15) |
 | #28 | Crash-loop when a slow spec fetch outran a client's connect timeout | PR #40 — handshake-first lazy load, clean stream exit, live-first cache |
 | #24 | `API_AUTH_TYPE` custom schemes (NetBox `Token`) sent **no** auth header | PR #25 — custom scheme prefix |

--- a/mcp_openapi_proxy/server_lowlevel.py
+++ b/mcp_openapi_proxy/server_lowlevel.py
@@ -14,8 +14,8 @@ Configuration is controlled via environment variables:
 - CAPABILITIES_RESOURCES: Set to "true" to enable resources advertising (default: false).
 - CAPABILITIES_PROMPTS: Set to "true" to enable prompts advertising (default: false).
 - ENABLE_TOOLS: Set to "false" to disable tools functionality (default: true).
-- ENABLE_RESOURCES: Set to "true" to enable resources functionality (default: false).
-- ENABLE_PROMPTS: Set to "true" to enable prompts functionality (default: false).
+- ENABLE_RESOURCES: Set to "false" to disable resources functionality (default: true).
+- ENABLE_PROMPTS: Set to "false" to disable prompts functionality (default: true).
 """
 
 import os
@@ -53,10 +53,13 @@ CAPABILITIES_TOOLS = os.getenv("CAPABILITIES_TOOLS", "false").lower() == "true"
 CAPABILITIES_RESOURCES = os.getenv("CAPABILITIES_RESOURCES", "false").lower() == "true"
 CAPABILITIES_PROMPTS = os.getenv("CAPABILITIES_PROMPTS", "false").lower() == "true"
 
-# Check feature enablement envvars (tools on, others off by default)
+# Feature enablement (all on by default). Advertising a capability is
+# required for clients to even attempt prompts/list & resources/list;
+# defaulting these OFF made prompts/resources invisible to every client
+# despite being implemented. Set to "false" to opt out.
 ENABLE_TOOLS = os.getenv("ENABLE_TOOLS", "true").lower() == "true"
-ENABLE_RESOURCES = os.getenv("ENABLE_RESOURCES", "false").lower() == "true"
-ENABLE_PROMPTS = os.getenv("ENABLE_PROMPTS", "false").lower() == "true"
+ENABLE_RESOURCES = os.getenv("ENABLE_RESOURCES", "true").lower() == "true"
+ENABLE_PROMPTS = os.getenv("ENABLE_PROMPTS", "true").lower() == "true"
 
 # Resource and prompt DEFINITIONS are always present so the feature is
 # deterministically testable. Whether they are EXPOSED to clients is gated

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "mcp-openapi-proxy"
 requires-python = ">=3.10"
-version = "0.2.1"
+version = "0.3.0"
 description = "MCP server for exposing OpenAPI specifications as MCP tools."
 readme = "README.md"
 authors = [

--- a/tests/integration/test_client_discovery.py
+++ b/tests/integration/test_client_discovery.py
@@ -190,3 +190,41 @@ def test_simple_mode_tools_discoverable(simple_server):
     assert "result" in tools, f"tools/list errored: {tools}"
     names = [t["name"] for t in tools["result"]["tools"]]
     assert "list_functions" in names and "call_function" in names, names
+
+
+@pytest.fixture
+def server_default_caps(tmp_path):
+    """Server with NO ENABLE_*/CAPABILITIES_* set — exercises the shipped
+    DEFAULTS. Regression guard: prompts/resources used to default OFF, so the
+    server advertised tools only and every client was blind to them."""
+    spec_path = tmp_path / "spec.json"
+    spec_path.write_text(json.dumps(SPEC))
+    env = dict(os.environ)
+    for k in ("ENABLE_RESOURCES", "ENABLE_PROMPTS", "ENABLE_TOOLS",
+              "CAPABILITIES_RESOURCES", "CAPABILITIES_PROMPTS", "CAPABILITIES_TOOLS"):
+        env.pop(k, None)
+    env.update({"OPENAPI_SPEC_URL": spec_path.as_uri(), "DEBUG": "false"})
+    proc = subprocess.Popen(
+        [sys.executable, "-c", "from mcp_openapi_proxy import main; main()"],
+        stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+        env=env, text=True,
+    )
+    try:
+        yield proc
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except Exception:
+            proc.kill()
+
+
+def test_defaults_advertise_prompts_and_resources(server_default_caps):
+    """By DEFAULT (no env flags) the low-level server must advertise prompts and
+    resources, not just tools — otherwise spec-compliant clients never call
+    prompts/list or resources/list and the features are invisible."""
+    client = StdioClient(server_default_caps)
+    caps = _initialize(client).get("capabilities", {})
+    assert caps.get("tools") is not None, f"tools missing by default: {caps}"
+    assert caps.get("prompts") is not None, f"prompts not advertised by default: {caps}"
+    assert caps.get("resources") is not None, f"resources not advertised by default: {caps}"


### PR DESCRIPTION
## Why
The low-level server gated prompts/resources behind `ENABLE_PROMPTS` / `ENABLE_RESOURCES`, which **defaulted OFF**. Per the MCP spec, a client won't call `prompts/list` / `resources/list` unless the capability is advertised in `initialize` — so the off-by-default silently made both surfaces **invisible to every client at once**, even though they're implemented and served correctly.

This also means the 0.2.0 verification sweep mis-attributed the proxy's own default to a "client-ecosystem gap."

## What
- **Default `ENABLE_PROMPTS` / `ENABLE_RESOURCES` to `true`** (opt out with `=false`).
- **Regression test**: asserts the DEFAULT (no env vars) advertises prompts + resources, not just tools.
- **Corrected the client matrix** (README + case study) after re-running the **real client binaries** with advertising enabled:
  - **Qwen** surfaces prompts (slash commands) — was ❌
  - **Kilocode** surfaces resources (`access_mcp_resource`) — was ❌
  - Gemini: prompts interactive-only; Vibe: tools-only (confirmed in source). Codex/opencode/Letta not re-run this pass (noted as such).
- Net: residual prompt/resource gap is real and client-side, but **not universal**; the proxy advertises and serves both correctly once advertising is on.

## Tests
`158 passed, 27 skipped` (skips are external-API integrations needing creds), including the new default-advertisement regression test.