### PR TITLE
docs: client matrix verified against published 0.3.0 (0.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.3.1
+
+### Docs
+- **Client matrix re-verified against the published 0.3.0 release** (no flags, default-on
+  advertising), driving every available real client binary. Filled the previously
+  "unknown" cells with evidence:
+  - **opencode** surfaces tools + prompts + resources — the only client that does all three.
+  - **Codex** surfaces tools + resources (`read_mcp_resource`); no prompt mechanism.
+  - **Kilocode** tools + resources; **Qwen** tools + prompts (slash); **Gemini** tools
+    (prompts/resources interactive-only); **Vibe** tools-only.
+  - **Letta** marked unknown — not testable headless (needs a running server + model).
+- No code changes; README is the PyPI long-description, so the corrected matrix ships to devs.
+
 ## 0.3.0
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -153,27 +153,32 @@ The example configurations below were exercised against the live APIs, and the p
 
 | Agent CLI | Model used (live test) | MCP attach mechanism | Tool calls | Prompts/Resources surfaced to model? |
 |---|---|---|---|---|
-| Codex | `gpt-5-codex` (OpenAI API) | `codex exec -c mcp_servers.*` | ✅ native | unknown ‡ |
-| Gemini | Google OAuth free tier (CLI default model) | project `.gemini/settings.json` `mcpServers` | ✅ native | prompts: interactive slash only · resources: ❌ † |
-| Qwen | `agent` group via local LiteLLM gateway | project `.qwen/settings.json` | ✅ native | prompts: ✅ (slash `/summarize_spec`) · resources: ❌ † |
-| Kilocode | `kilo-auto/free` | global `settings/mcp_settings.json`, clean workspace | ✅ native | prompts: ❌ · resources: ✅ (`access_mcp_resource`) † |
-| opencode | `orchestration` group via local LiteLLM gateway | `~/.config/opencode/opencode.json` `mcp` | ✅ native | unknown ‡ |
-| Vibe | `mistral-medium-3.5` | `~/.vibe/config.toml` `[[mcp_servers]]` | ✅ discovery + reads (writes flaky) | prompts: ❌ · resources: ❌ (tools-only) † |
+| **opencode** | (CLI default) | `~/.config/opencode/opencode.json` `mcp` | ✅ native | **prompts: ✅ (slash) · resources: ✅** — most complete ‖ |
+| Codex | `gpt-5-codex` (OpenAI API) | `codex exec -c mcp_servers.*` | ✅ native | prompts: ❌ (no prompt meta-tools) · resources: ✅ (`read_mcp_resource`) ‖ |
+| Kilocode | `kilo-auto/free` | global `settings/mcp_settings.json` | ✅ native | prompts: ❌ (no prompt mechanism) · resources: ✅ (`access_mcp_resource`) ‖ |
+| Qwen | `agent` group via local LiteLLM gateway | project `.qwen/settings.json` | ✅ native (live invoke auth-blocked) | prompts: ✅ (slash `/summarize_spec`) · resources: ❌ (no client support) ‖ |
+| Gemini | Google OAuth free tier (CLI default model) | project `.gemini/settings.json` `mcpServers` | ✅ native | prompts: interactive slash only · resources: interactive `@` only (neither reaches the model headless) ‖ |
+| Vibe | `mistral-medium-3.5` | `~/.vibe/config.toml` `[[mcp_servers]]` | ✅ discovery + reads | prompts: ❌ · resources: ❌ (tools-only client) ‖ |
 | agy | — | — | ❌ headless cannot enable MCP | n/a |
-| letta cloud | Letta Cloud default | streamable-HTTP MCP URL (`/mcp add --transport http` + bearer) | ✅ remote (stdio rejected) | unknown ‡ |
-| letta (self-hosted ≤0.11.x) | `agent` group via local LiteLLM gateway | stdio via `PUT /v1/tools/mcp/servers` | ✅ native | unknown ‡ |
+| letta (cloud / self-hosted) | Letta Cloud / `PUT /v1/tools/mcp/servers` | streamable-HTTP / stdio | ✅ (per prior sweep) | unknown — needs a running Letta server to test ‡ |
 
-> **Prompts/resources column — read this.** The original 0.2.0 sweep ran while the
-> server advertised prompts/resources **only when `ENABLE_PROMPTS`/`ENABLE_RESOURCES`
-> were set — they defaulted OFF.** Per the MCP spec a client won't call
-> `prompts/list`/`resources/list` unless the capability is advertised, so those early
-> results measured the *server's* default, not the clients. **All prior prompt/resource
-> findings are therefore voided.** This release defaults advertising **on**.
+> **How to read the prompts/resources column.** MCP has three surfaces — tools, prompts,
+> resources. **mcp-openapi-proxy serves all three, advertised by default since 0.3.0.**
+> Whether they reach the model is up to the *client*, and that varies:
 >
-> - **† re-verified 2026-06-14** with advertising on, against the real client binary. Genuine, uneven: **tools** everywhere; **prompts→model** Qwen (slash) & Gemini (interactive only); **resources→model** Kilocode. Vibe is tools-only (confirmed in source).
-> - **‡ unknown** — not yet re-tested under advertising-on (opencode not installed here; Letta needs a running server + gateway; Codex parked). Prior ❌ values are not carried forward.
+> - **‖ re-verified 2026-06-14 against the published 0.3.0 release** with **no** flags set
+>   (validating the default-on advertising), driving each **real client binary**.
+> - **Tools** work on every client tested. **Prompts→model**: opencode & Qwen (slash
+>   commands); Gemini interactive-only. **Resources→model**: opencode, Codex, Kilocode.
+>   **opencode is the only client that surfaces all three.** Vibe is tools-only.
+> - **‡ unknown** — Letta can't be exercised without standing up a Letta server + model;
+>   left untested rather than guessed.
+> - Every cell on the proxy side was confirmed via a raw stdio handshake (`initialize`
+>   advertises tools+prompts+resources; `prompts/get` and `resources/read` return content).
+>   The remaining ❌ are **client-side** gaps, not proxy limitations.
 >
-> Tool-calling (the `Tool calls` column) was unaffected by the advertising default and stands as originally verified.
+> *(All pre-0.3.0 prompt/resource findings were voided — they were measured while
+> advertising defaulted off, so they reflected the server default, not the clients.)*
 
 Minimal sanitized configs per client (the no-auth Glama spec is used as the smallest working example; substitute your own spec URL and `$YOUR_KEY` as needed):
 

--- a/docs/verification-case-study.md
+++ b/docs/verification-case-study.md
@@ -49,35 +49,40 @@ sane tool count.
 
 | Client | Model (live test) | MCP attach mechanism | Tool calls | Prompts/resources to model |
 | --- | --- | --- | --- | --- |
-| Codex | gpt-5-codex | `codex exec -c mcp_servers.*` | ✅ native | unknown ‡ |
-| Gemini | Google OAuth tier | project `.gemini/settings.json` | ✅ native | prompts: interactive slash only · resources: ❌ † |
-| Qwen | gateway model group | project `.qwen/settings.json` | ✅ native | prompts: ✅ (slash) · resources: ❌ † |
-| Kilocode | free auto model | global `mcp_settings.json` | ✅ native | prompts: ❌ · resources: ✅ (`access_mcp_resource`) † |
-| opencode | gateway model group | `opencode.json` `mcp` | ✅ native | unknown ‡ |
-| Vibe | mistral-medium-3.5 | `~/.vibe/config.toml` `[[mcp_servers]]` | ✅ discovery + reads | prompts: ❌ · resources: ❌ (tools-only) † |
+| opencode | (CLI default) | `opencode.json` `mcp` | ✅ native | **prompts: ✅ (slash) · resources: ✅ — most complete** ‖ |
+| Codex | gpt-5-codex | `codex exec -c mcp_servers.*` | ✅ native | prompts: ❌ (no prompt meta-tools) · resources: ✅ (`read_mcp_resource`) ‖ |
+| Kilocode | free auto model | global `mcp_settings.json` | ✅ native | prompts: ❌ · resources: ✅ (`access_mcp_resource`) ‖ |
+| Qwen | gateway model group | project `.qwen/settings.json` | ✅ native (live invoke auth-blocked) | prompts: ✅ (slash) · resources: ❌ ‖ |
+| Gemini | Google OAuth tier | project `.gemini/settings.json` | ✅ native | prompts: interactive slash only · resources: interactive `@` only ‖ |
+| Vibe | mistral-medium-3.5 | `~/.vibe/config.toml` `[[mcp_servers]]` | ✅ discovery + reads | prompts: ❌ · resources: ❌ (tools-only client) ‖ |
 | agy | — | — | ❌ headless can't enable MCP | n/a |
-| Letta (self-hosted) | gateway model group | stdio via `PUT /v1/tools/mcp/servers` | ✅ native | unknown ‡ |
-| Letta Cloud | Letta default | remote streamable-HTTP MCP URL | ✅ (stdio rejected) | unknown ‡ |
+| Letta (cloud / self-hosted) | Letta Cloud / `PUT /v1/tools/mcp/servers` | streamable-HTTP / stdio | ✅ (prior sweep) | unknown — needs a running Letta server to test ‡ |
 
-*† re-verified 2026-06-14 with advertising on (real binary). ‡ not yet re-tested under advertising-on — prior 0.2.0 prompt/resource results are **voided** (they were measured while the server defaulted to advertising neither). Tool-call results were unaffected and stand.*
+*‖ re-verified 2026-06-14 against the **published 0.3.0** release with no flags set (default-on advertising), driving each real client binary. ‡ Letta not exercised — needs a running server + model, not feasible headless. All pre-0.3.0 prompt/resource results were **voided** (measured while advertising defaulted off). Tool-call results were unaffected and stand.*
 
 **Systemic finding:** every CLI tested could call MCP *tools* natively. Surfacing of
 MCP *prompts/resources* to the model is uneven across clients — but read the correction
 below before concluding it's purely a client gap.
 
-> **† Correction (2026-06-14).** This original sweep ran against a build where the
-> low-level server advertised prompts/resources **only when `ENABLE_PROMPTS`/`ENABLE_RESOURCES`
-> were explicitly set — they defaulted OFF.** Per the MCP spec, a client will not call
-> `prompts/list`/`resources/list` unless the capability is advertised in `initialize`, so
-> a server that doesn't advertise makes prompts/resources invisible to **every** client at
-> once. Part of the original "client-ecosystem gap" was therefore the proxy's own default,
-> not the clients. That default is now **on** (advertising by default; opt out with
-> `ENABLE_PROMPTS=false`/`ENABLE_RESOURCES=false`). Re-running the **real** client binaries
-> with advertising enabled: **tools** universal; **prompts→model** on Qwen (slash commands)
-> and Gemini (interactive only); **resources→model** on Kilocode (`access_mcp_resource`).
-> Vibe remains tools-only (no prompt/resource client support — confirmed in source); Codex,
-> opencode, and Letta were not re-run in this pass. So the residual gap is real and
-> client-side, but **not universal** — and the proxy serves both correctly once it advertises.
+> **Correction & re-verification (2026-06-14, published 0.3.0).** The original sweep ran
+> against a build where the low-level server advertised prompts/resources **only when
+> `ENABLE_PROMPTS`/`ENABLE_RESOURCES` were explicitly set — they defaulted OFF.** Per the
+> MCP spec a client won't call `prompts/list`/`resources/list` unless the capability is
+> advertised in `initialize`, so a server that doesn't advertise makes prompts/resources
+> invisible to **every** client at once. Much of the original "client-ecosystem gap" was
+> therefore the proxy's own default, not the clients. **0.3.0 defaults advertising on**
+> (opt out with `ENABLE_PROMPTS=false`/`ENABLE_RESOURCES=false`).
+>
+> Re-running **every available client binary against the published 0.3.0 with no flags**:
+> - **tools** — universal.
+> - **prompts→model** — **opencode** & **Qwen** (slash commands); **Gemini** interactive-only.
+> - **resources→model** — **opencode**, **Codex** (`read_mcp_resource`), **Kilocode** (`access_mcp_resource`).
+> - **opencode is the only client that surfaces all three.** **Vibe** is tools-only;
+>   **Codex/Kilocode** lack a prompt mechanism; **Qwen/Gemini** lack model-facing resources.
+> - **Letta** could not be tested headless (needs a running server + model) — marked unknown.
+>
+> So the residual gap is real, client-side, and **uneven — not universal**; the proxy
+> advertises and serves all three correctly by default.
 
 ## Prompts & resources
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "mcp-openapi-proxy"
 requires-python = ">=3.10"
-version = "0.3.0"
+version = "0.3.1"
 description = "MCP server for exposing OpenAPI specifications as MCP tools."
 readme = "README.md"
 authors = [


### PR DESCRIPTION
Re-ran **every available real client binary** against the **published 0.3.0** release with **no flags** (validating default-on advertising), and filled the previously-unknown matrix cells with evidence. Docs-only; bumps to 0.3.1 so the corrected matrix ships in the PyPI long-description.

## Verified client surfacing (0.3.0, no flags)
| Client | tools | prompts→model | resources→model |
|---|---|---|---|
| **opencode** | ✅ | ✅ (slash) | ✅ — only client doing all three |
| Codex | ✅ | ❌ | ✅ (`read_mcp_resource`) |
| Kilocode | ✅ | ❌ | ✅ (`access_mcp_resource`) |
| Qwen | ✅* | ✅ (slash) | ❌ |
| Gemini | ✅ | interactive-only | interactive-only |
| Vibe | ✅ | ❌ | ❌ |
| Letta | — | — | — (needs a running server; unknown) |

All proxy-side surfaces confirmed via raw stdio (`initialize` advertises all three; `prompts/get`/`resources/read` return content). Remaining ❌ are client-side gaps. *Qwen live tool invoke was auth-blocked; surfacing confirmed in source.

Tests: 158 passed, 27 skipped.