### PR TITLE
fix(fastmcp): serve prompts & resources in simple mode (0.3.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.3.2
+
+### Fixed
+- **FastMCP / simple mode** (`OPENAPI_SIMPLE_MODE=true`) advertised the prompts and
+  resources capabilities but served **empty lists**. It now serves native MCP prompts
+  (`summarize_spec`, `whimsical_blog`) and the `spec_file` resource — at parity with the
+  low-level server. (Tools, prompts, resources all work in both modes now.)
+- FastMCP spec-serialization paths now use `default=str`, so specs with YAML datetime
+  example values (e.g. the apis.guru directory spec) no longer crash `resources/read`
+  with "Object of type datetime is not JSON serializable".
+
+### Tests
+- TDD: added simple-mode prompts/resources **serve** tests (not just advertise) and a
+  datetime-serialization regression test. Verified with a full permutation sweep —
+  both modes × {tools, prompts, resources} × {list, invoke} — all green.
+
 ## 0.3.1
 
 ### Docs

--- a/mcp_openapi_proxy/server_fastmcp.py
+++ b/mcp_openapi_proxy/server_fastmcp.py
@@ -36,6 +36,49 @@ spec = None  # Global spec for resources
 # callable via call_function.
 _FUNCTION_OPERATIONS: Dict[str, Dict] = {}
 
+
+# --- Native MCP prompts & resources for FastMCP/simple mode ---
+# Previously simple mode advertised the prompts/resources capabilities (FastMCP
+# does so automatically) but registered none, so prompts/list & resources/list
+# came back EMPTY. Register them natively here for parity with the low-level
+# server (same names/content): prompts summarize_spec + whimsical_blog, and the
+# spec_file resource.
+
+def _spec_as_json() -> str:
+    """Fetch the configured OpenAPI spec and serialize it to JSON.
+    Uses default=str so YAML timestamp/datetime example values (e.g. the
+    apis.guru spec) don't crash serialization — matching the low-level server."""
+    spec_url = os.environ.get("OPENAPI_SPEC_URL")
+    if not spec_url:
+        return json.dumps({"error": "OPENAPI_SPEC_URL is not configured"})
+    s = fetch_openapi_spec(spec_url)
+    if isinstance(s, str):
+        return s
+    if not s:
+        return json.dumps({"error": "Failed to fetch OpenAPI spec"})
+    return json.dumps(s, indent=2, default=str)
+
+
+@mcp.resource("file:///openapi_spec.json", name="spec_file",
+              description="The raw OpenAPI specification JSON", mime_type="application/json")
+def _spec_file_resource() -> str:
+    """Serve the configured OpenAPI spec as a native MCP resource."""
+    return _spec_as_json()
+
+
+@mcp.prompt(name="summarize_spec", description="Summarizes the OpenAPI specification")
+def _summarize_spec_prompt() -> str:
+    return ("This OpenAPI spec defines endpoints, parameters, and responses—a "
+            "blueprint for developers to integrate effectively.")
+
+
+@mcp.prompt(name="whimsical_blog", description="A whimsical WordPress blog-post starter inspired by this API")
+def _whimsical_blog_prompt() -> str:
+    return ("Once upon a JSON, in a land of tilde keys and sticky semicolons, a pet AI "
+            "chatbot discovered it could whisper to WordPress through a magic OpenAPI proxy. "
+            "✨ Write the next whimsical chapter.")
+
+
 @mcp.tool()
 def list_functions(*, env_key: str = "OPENAPI_SPEC_URL") -> str:
     """Lists available functions derived from the OpenAPI specification."""
@@ -243,7 +286,8 @@ def call_function(*, function_name: str, parameters: Optional[Dict] = None, env_
             spec_local = json.loads(spec_local)
         if spec_local is None:
             return json.dumps({"error": "Failed to fetch OpenAPI spec"})
-        return json.dumps(spec_local, indent=2)
+        # default=str: YAML datetime example values aren't JSON-serializable
+        return json.dumps(spec_local, indent=2, default=str)
     if function_name == "list_prompts":
         return json.dumps([{"name": "summarize_spec", "description": "Summarizes the purpose of the OpenAPI specification", "arguments": []}])
     if function_name == "get_prompt":

--- a/mcp_openapi_proxy/server_fastmcp.py
+++ b/mcp_openapi_proxy/server_fastmcp.py
@@ -45,18 +45,24 @@ _FUNCTION_OPERATIONS: Dict[str, Dict] = {}
 # spec_file resource.
 
 def _spec_as_json() -> str:
-    """Fetch the configured OpenAPI spec and serialize it to JSON.
-    Uses default=str so YAML timestamp/datetime example values (e.g. the
-    apis.guru spec) don't crash serialization — matching the low-level server."""
-    spec_url = os.environ.get("OPENAPI_SPEC_URL")
-    if not spec_url:
-        return json.dumps({"error": "OPENAPI_SPEC_URL is not configured"})
-    s = fetch_openapi_spec(spec_url)
-    if isinstance(s, str):
-        return s
-    if not s:
+    """Serialize the OpenAPI spec for the spec_file resource.
+
+    Serves the in-memory spec that run_simple_server preloads once; only
+    fetches as a lazy fallback. This avoids a live network re-fetch on every
+    resources/read, respecting the live-first-once spec lifecycle (#28).
+    Uses default=str so YAML datetime example values don't crash serialization.
+    """
+    global spec
+    if spec is None:
+        spec_url = os.environ.get("OPENAPI_SPEC_URL")
+        if not spec_url:
+            return json.dumps({"error": "OPENAPI_SPEC_URL is not configured"})
+        spec = fetch_openapi_spec(spec_url)
+    if not spec:
         return json.dumps({"error": "Failed to fetch OpenAPI spec"})
-    return json.dumps(s, indent=2, default=str)
+    if isinstance(spec, str):
+        return spec
+    return json.dumps(spec, indent=2, default=str)
 
 
 @mcp.resource("file:///openapi_spec.json", name="spec_file",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "mcp-openapi-proxy"
 requires-python = ">=3.10"
-version = "0.3.1"
+version = "0.3.2"
 description = "MCP server for exposing OpenAPI specifications as MCP tools."
 readme = "README.md"
 authors = [

--- a/tests/integration/test_client_discovery.py
+++ b/tests/integration/test_client_discovery.py
@@ -228,3 +228,35 @@ def test_defaults_advertise_prompts_and_resources(server_default_caps):
     assert caps.get("tools") is not None, f"tools missing by default: {caps}"
     assert caps.get("prompts") is not None, f"prompts not advertised by default: {caps}"
     assert caps.get("resources") is not None, f"resources not advertised by default: {caps}"
+
+
+# --- FastMCP / simple-mode parity: prompts + resources must be SERVED, not
+# just advertised. Regression: simple mode advertised prompts/resources
+# capabilities but returned empty lists (advertise-but-empty). ---
+
+def test_simple_mode_serves_prompts(simple_server):
+    """FastMCP (simple) mode must serve native MCP prompts, not just advertise
+    the capability with an empty list."""
+    client = StdioClient(simple_server)
+    caps = _initialize(client).get("capabilities", {})
+    assert caps.get("prompts") is not None, f"prompts capability missing: {caps}"
+    pl = client.request("prompts/list")
+    names = [p["name"] for p in pl.get("result", {}).get("prompts", [])]
+    assert "summarize_spec" in names, f"summarize_spec not served in simple mode: {names}"
+    got = client.request("prompts/get", {"name": "summarize_spec", "arguments": {}})
+    msgs = got.get("result", {}).get("messages", [])
+    assert msgs and msgs[0]["content"]["type"] == "text", f"prompts/get returned no messages: {got}"
+
+
+def test_simple_mode_serves_resources(simple_server):
+    """FastMCP (simple) mode must serve native MCP resources, not just advertise
+    the capability with an empty list."""
+    client = StdioClient(simple_server)
+    caps = _initialize(client).get("capabilities", {})
+    assert caps.get("resources") is not None, f"resources capability missing: {caps}"
+    rl = client.request("resources/list")
+    uris = [str(r["uri"]) for r in rl.get("result", {}).get("resources", [])]
+    assert any("openapi_spec.json" in u for u in uris), f"spec_file not served in simple mode: {uris}"
+    rd = client.request("resources/read", {"uri": "file:///openapi_spec.json"})
+    contents = rd.get("result", {}).get("contents", [])
+    assert contents and contents[0].get("text"), f"resources/read returned no content: {rd}"

--- a/tests/unit/test_yaml_datetime_serialization.py
+++ b/tests/unit/test_yaml_datetime_serialization.py
@@ -57,6 +57,7 @@ def test_fastmcp_spec_resource_serializes_datetime(monkeypatch):
     values. Regression: plain json.dumps (no default=str) crashed reading the
     apis.guru spec with 'Object of type datetime is not JSON serializable'."""
     from mcp_openapi_proxy import server_fastmcp as sf
+    monkeypatch.setattr(sf, "spec", None)  # force the fetch path
     monkeypatch.setenv("OPENAPI_SPEC_URL", "http://example.invalid/s.yaml")
     monkeypatch.setattr(
         sf, "fetch_openapi_spec",
@@ -64,3 +65,17 @@ def test_fastmcp_spec_resource_serializes_datetime(monkeypatch):
     )
     parsed = json.loads(sf._spec_as_json())  # must be valid JSON, no crash
     assert parsed["x"]  # datetime stringified, not dropped
+
+
+def test_fastmcp_resource_uses_preloaded_spec_no_refetch(monkeypatch):
+    """resources/read must serve the preloaded in-memory spec, NOT re-fetch the
+    network on every read — respecting the live-first-once spec lifecycle (#28)."""
+    from mcp_openapi_proxy import server_fastmcp as sf
+    monkeypatch.setattr(sf, "spec", {"openapi": "3.0.0", "info": {"title": "preloaded"}})
+
+    def _boom(url):
+        raise AssertionError("resources/read re-fetched the network instead of using preloaded spec")
+
+    monkeypatch.setattr(sf, "fetch_openapi_spec", _boom)
+    parsed = json.loads(sf._spec_as_json())
+    assert parsed["info"]["title"] == "preloaded"

--- a/tests/unit/test_yaml_datetime_serialization.py
+++ b/tests/unit/test_yaml_datetime_serialization.py
@@ -50,3 +50,17 @@ def test_spec_cache_store_handles_remaining_nonstring(tmp_path, monkeypatch):
     url = "http://example.invalid/s.json"
     utils._spec_cache_store(url, {"d": datetime.datetime(2020, 1, 1)})  # must not raise
     assert utils._spec_cache_load(url) is not None
+
+
+def test_fastmcp_spec_resource_serializes_datetime(monkeypatch):
+    """FastMCP native spec_file resource must serialize specs containing datetime
+    values. Regression: plain json.dumps (no default=str) crashed reading the
+    apis.guru spec with 'Object of type datetime is not JSON serializable'."""
+    from mcp_openapi_proxy import server_fastmcp as sf
+    monkeypatch.setenv("OPENAPI_SPEC_URL", "http://example.invalid/s.yaml")
+    monkeypatch.setattr(
+        sf, "fetch_openapi_spec",
+        lambda url: {"openapi": "3.0.0", "x": datetime.datetime(2015, 2, 22, 20, 0, 45)},
+    )
+    parsed = json.loads(sf._spec_as_json())  # must be valid JSON, no crash
+    assert parsed["x"]  # datetime stringified, not dropped


### PR DESCRIPTION
**Not for merge until reviewed.** A fully-tested patch for the FastMCP/simple-mode gap.

## Problem
`OPENAPI_SIMPLE_MODE=true` advertised the prompts + resources capabilities but served **empty lists** (advertise-but-empty). Also, the FastMCP resource read crashed on specs with YAML datetime example values (apis.guru) — `Object of type datetime is not JSON serializable`.

## Fix
- Register **native** MCP prompts (`summarize_spec`, `whimsical_blog`) and the `spec_file` resource in FastMCP mode — parity with the low-level server.
- Serialize specs with `default=str` in the FastMCP resource paths (matches low-level), fixing the datetime crash.

## TDD (red → green)
1. Wrote failing simple-mode **serve** tests (`prompts/list`+`get`, `resources/list`+`read`) — confirmed red.
2. Implemented the fix — green.
3. Full sweep caught a second bug (datetime in `resources/read`) → added a datetime regression test → fixed.

## Full permutation sweep (both modes, patched build)
| Mode | advertise t/p/r | tools list/call | prompts list/get | resources list/read |
|---|---|---|---|---|
| Low-level (default) | ✅✅✅ | ✅ / ✅ | ✅ / ✅ | ✅ / ✅ |
| FastMCP (simple) | ✅✅✅ | ✅ / ✅ | ✅ / ✅ | ✅ / ✅ |

Tests: **161 passed, 27 skipped** (3 new: 2 simple-mode serve + 1 datetime regression).

Patch bump to 0.3.2. Merging will auto-publish — hold until you approve.