### PR TITLE
Strip path params from non-GET bodies + Home Assistant example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.3.3
+
+### Fixed
+- Strip path parameters from **non-GET** request bodies (was GET-only). Substituted
+  `{path}` placeholders were left in `parameters` for POST/PUT/PATCH/DELETE and leaked
+  into the JSON body, so strict APIs returned 400 — e.g. Home Assistant
+  `POST /api/services/{domain}/{service}` rejected the body carrying `domain`/`service`.
+  Now stripped for all methods. Regression test added.
+
+### Added
+- Home Assistant example (`examples/homeassistant.openapi.json` +
+  `examples/homeassistant-claude_desktop_config.json`): generic REST slice
+  (get_config, list_states, get_state, list_services, call_service, get_history) with
+  named `call_service` body args. Auth via `EXTRA_HEADERS="Authorization: Bearer ${HA_TOKEN}"`
+  and `SERVER_URL_OVERRIDE`. Requires this release's fix for `call_service`.
+
 ## 0.3.2
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ The example configurations below were exercised against the live APIs, and the p
 | flyio | 34–35 | apps + machine health | `API_KEY` |
 | slack | 7 (exact dot-path whitelist until #27 fix) | `auth.test` + `postMessage` | `API_KEY` |
 | netbox | 9 (whitelist `/ipam/ip-addresses`) | IPAM write + read | `API_KEY` + `API_AUTH_TYPE=Token` |
+| homeassistant | 6 | `get_config` (200) + `call_service` (light.turn_on, 200) | `SERVER_URL_OVERRIDE` + `EXTRA_HEADERS` (`Authorization: Bearer ${HA_TOKEN}`) |
 
 ### Client matrix
 
@@ -910,6 +911,49 @@ printf 'myuser:xxxx xxxx xxxx xxxx xxxx xxxx' | base64 -w0
 ```
 
 Tips: set `IGNORE_SSL_TOOLS=true` only if your host serves a self-signed/mismatched cert; give each agent its own (revocable) application password; keep `TOOL_WHITELIST=/wp/v2/posts` so the agent can touch only posts.
+
+</details>
+
+<details>
+<summary><b>Home Assistant Example</b> — control your smart home; <code>call_service</code> needs the >= 0.3.3 path-param body fix</summary>
+
+Exposes a small generic slice of the Home Assistant REST API: `get_config`, `list_states`,
+`get_state`, `list_services`, `call_service`, `get_history`.
+
+#### 1. Verify the OpenAPI specification
+
+```bash
+curl https://raw.githubusercontent.com/matthewhand/mcp-openapi-proxy/refs/heads/main/examples/homeassistant.openapi.json
+```
+
+#### 2. Configure mcp-openapi-proxy for Home Assistant
+
+```json
+{
+    "mcpServers": {
+        "homeassistant": {
+            "command": "uvx",
+            "args": ["mcp-openapi-proxy"],
+            "env": {
+                "OPENAPI_SPEC_URL": "https://raw.githubusercontent.com/matthewhand/mcp-openapi-proxy/refs/heads/main/examples/homeassistant.openapi.json",
+                "SERVER_URL_OVERRIDE": "http://homeassistant.local:8123",
+                "EXTRA_HEADERS": "Authorization: Bearer ${HA_TOKEN}"
+            }
+        }
+    }
+}
+```
+
+Key configuration points:
+- `SERVER_URL_OVERRIDE` — your instance base URL, e.g. `http://homeassistant.local:8123` or `http://<ha-host>:8123`.
+- `HA_TOKEN` — a Home Assistant **long-lived access token** (Profile → Long-Lived Access Tokens), passed via `EXTRA_HEADERS`. Never commit the token; keep it in your environment.
+- `call_service` requires **mcp-openapi-proxy >= 0.3.3**: earlier versions leaked the `{domain}`/`{service}` path params into the JSON body, which Home Assistant rejects with HTTP 400.
+
+#### 3. Testing
+
+`get_config` should return your HA configuration (200). `call_service` for `light/turn_on`
+with body `{"entity_id": "light.kitchen"}` should return 200 — the path params land in the URL
+(`/api/services/light/turn_on`), not the body.
 
 </details>
 

--- a/examples/homeassistant-claude_desktop_config.json
+++ b/examples/homeassistant-claude_desktop_config.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "homeassistant": {
+      "command": "uvx",
+      "args": [
+        "mcp-openapi-proxy"
+      ],
+      "env": {
+        "OPENAPI_SPEC_URL": "https://raw.githubusercontent.com/matthewhand/mcp-openapi-proxy/refs/heads/main/examples/homeassistant.openapi.json",
+        "SERVER_URL_OVERRIDE": "http://homeassistant.local:8123",
+        "EXTRA_HEADERS": "Authorization: Bearer ${HA_TOKEN}"
+      }
+    }
+  }
+}

--- a/examples/homeassistant.openapi.json
+++ b/examples/homeassistant.openapi.json
@@ -1,0 +1,87 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Home Assistant REST API (example subset)",
+    "version": "1.0.0",
+    "description": "Minimal, generic Home Assistant REST API spec for mcp-openapi-proxy. Point SERVER_URL_OVERRIDE at your instance (http://<ha-host>:8123) and authenticate with a long-lived access token via EXTRA_HEADERS=\"Authorization: Bearer ${HA_TOKEN}\". call_service requires the path-parameter body-strip fix (>= 0.3.3)."
+  },
+  "servers": [
+    { "url": "http://homeassistant.local:8123" }
+  ],
+  "paths": {
+    "/api/config": {
+      "get": {
+        "operationId": "get_config",
+        "summary": "Get the Home Assistant configuration",
+        "responses": { "200": { "description": "OK" } }
+      }
+    },
+    "/api/states": {
+      "get": {
+        "operationId": "list_states",
+        "summary": "List the state of every entity",
+        "responses": { "200": { "description": "OK" } }
+      }
+    },
+    "/api/states/{entity_id}": {
+      "get": {
+        "operationId": "get_state",
+        "summary": "Get the state of one entity",
+        "parameters": [
+          { "name": "entity_id", "in": "path", "required": true, "schema": { "type": "string" }, "description": "Entity id, e.g. light.kitchen" }
+        ],
+        "responses": { "200": { "description": "OK" } }
+      }
+    },
+    "/api/services": {
+      "get": {
+        "operationId": "list_services",
+        "summary": "List the available services per domain",
+        "responses": { "200": { "description": "OK" } }
+      }
+    },
+    "/api/services/{domain}/{service}": {
+      "post": {
+        "operationId": "call_service",
+        "summary": "Call a service, e.g. light.turn_on or notify.notify",
+        "parameters": [
+          { "name": "domain", "in": "path", "required": true, "schema": { "type": "string" }, "description": "Service domain, e.g. light" },
+          { "name": "service", "in": "path", "required": true, "schema": { "type": "string" }, "description": "Service name, e.g. turn_on" }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "description": "Service data. Common fields are named so they surface as tool arguments; arbitrary extra fields are allowed.",
+                "properties": {
+                  "entity_id": { "type": "string", "description": "Target entity or list, e.g. light.kitchen" },
+                  "message": { "type": "string", "description": "Message body for notify.* services" },
+                  "title": { "type": "string", "description": "Title for notify.* services" },
+                  "brightness_pct": { "type": "integer", "description": "Light brightness 0-100" },
+                  "color_name": { "type": "string", "description": "CSS color name for lights" },
+                  "temperature": { "type": "number", "description": "Target temperature (climate)" },
+                  "hvac_mode": { "type": "string", "description": "Climate mode, e.g. heat, cool, off" },
+                  "code": { "type": "string", "description": "Code for lock/alarm services" }
+                },
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "responses": { "200": { "description": "OK" } }
+      }
+    },
+    "/api/history/period/{timestamp}": {
+      "get": {
+        "operationId": "get_history",
+        "summary": "Get state history starting at a timestamp",
+        "parameters": [
+          { "name": "timestamp", "in": "path", "required": true, "schema": { "type": "string" }, "description": "ISO 8601 start time, e.g. 2024-01-01T00:00:00+00:00" }
+        ],
+        "responses": { "200": { "description": "OK" } }
+      }
+    }
+  }
+}

--- a/mcp_openapi_proxy/server_lowlevel.py
+++ b/mcp_openapi_proxy/server_lowlevel.py
@@ -249,14 +249,19 @@ async def dispatcher_handler(request: types.CallToolRequest) -> types.CallToolRe
         try:
             path = path.format(**parameters)
             logger.debug(f"Substituted path using format(): {path}")
-            if method == "GET":
-                placeholder_keys = [
-                    seg.strip("{}")
-                    for seg in operation_details["original_path"].split("/")
-                    if seg.startswith("{") and seg.endswith("}")
-                ]
-                for key in placeholder_keys:
-                    parameters.pop(key, None)
+            # Path placeholders are now substituted into the URL, so drop them from
+            # `parameters` for ALL methods. Previously this ran only for GET, so on
+            # POST/PUT/PATCH/DELETE the path params leaked into request_body and
+            # strict APIs rejected the unexpected fields -- e.g. Home Assistant
+            # POST /api/services/{domain}/{service} returned HTTP 400 because the
+            # body carried domain/service.
+            placeholder_keys = [
+                seg.strip("{}")
+                for seg in operation_details["original_path"].split("/")
+                if seg.startswith("{") and seg.endswith("}")
+            ]
+            for key in placeholder_keys:
+                parameters.pop(key, None)
         except KeyError as e:
             logger.error(f"Missing parameter for substitution: {e}")
             return types.CallToolResult(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "mcp-openapi-proxy"
 requires-python = ">=3.10"
-version = "0.3.2"
+version = "0.3.3"
 description = "MCP server for exposing OpenAPI specifications as MCP tools."
 readme = "README.md"
 authors = [

--- a/tests/unit/test_path_params_non_get_body.py
+++ b/tests/unit/test_path_params_non_get_body.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+"""Regression: path parameters must be stripped from non-GET request bodies.
+
+The placeholder strip previously ran only for GET, so on POST/PUT/PATCH/DELETE
+the substituted path params leaked into the JSON body and strict APIs rejected
+the unexpected fields -- e.g. Home Assistant POST /api/services/{domain}/{service}
+returned HTTP 400 because the body carried domain/service.
+"""
+import unittest
+import os
+import asyncio
+from types import SimpleNamespace
+
+import requests
+
+from mcp_openapi_proxy.handlers import register_functions
+from mcp_openapi_proxy.server_lowlevel import tools, dispatcher_handler
+import mcp_openapi_proxy.utils as utils
+
+
+class TestPathParamsNonGetBody(unittest.TestCase):
+    def setUp(self):
+        tools.clear()
+        self.old_wl = os.environ.get("TOOL_WHITELIST")
+        os.environ["TOOL_WHITELIST"] = ""
+        self.old_is_wl = utils.is_tool_whitelisted
+        utils.is_tool_whitelisted = lambda endpoint: True
+        self.spec = {
+            "openapi": "3.0.0",
+            "servers": [{"url": "https://dummy-base-url.com"}],
+            "paths": {
+                "/widgets/{a}/{b}": {
+                    "post": {
+                        "summary": "Create widget",
+                        "parameters": [
+                            {"name": "a", "in": "path", "required": True, "schema": {"type": "string"}},
+                            {"name": "b", "in": "path", "required": True, "schema": {"type": "string"}},
+                        ],
+                        "requestBody": {
+                            "content": {"application/json": {"schema": {
+                                "type": "object",
+                                "properties": {"x": {"type": "string"}},
+                            }}}
+                        },
+                        "responses": {"200": {"description": "OK"}},
+                    }
+                }
+            },
+        }
+        register_functions(self.spec)
+        import mcp_openapi_proxy.server_lowlevel as lowlevel
+        lowlevel.openapi_spec_data = self.spec
+        self.assertEqual(len(tools), 1, "expected 1 tool registered")
+
+    def tearDown(self):
+        utils.is_tool_whitelisted = self.old_is_wl
+        if self.old_wl is not None:
+            os.environ["TOOL_WHITELIST"] = self.old_wl
+        else:
+            os.environ.pop("TOOL_WHITELIST", None)
+
+    def test_path_params_not_in_post_body(self):
+        """URL gets a/b substituted; JSON body carries only the requestBody prop x."""
+        req = SimpleNamespace(params=SimpleNamespace(
+            name=tools[0].name, arguments={"a": "foo", "b": "bar", "x": "hello"}))
+        captured = {}
+        orig = requests.request
+
+        def fake(method, url, **kwargs):
+            captured["method"] = method
+            captured["url"] = url
+            captured["json"] = kwargs.get("json")
+
+            class R:
+                status_code = 200
+                text = "{}"
+                headers = {"Content-Type": "application/json"}
+                def json(self_inner):
+                    return {}
+                def raise_for_status(self_inner):
+                    pass
+            return R()
+
+        requests.request = fake
+        try:
+            asyncio.run(dispatcher_handler(req))  # type: ignore
+        finally:
+            requests.request = orig
+
+        self.assertEqual(captured.get("method"), "POST")
+        self.assertIn("/widgets/foo/bar", captured.get("url", ""),
+                      f"path not substituted into URL: {captured.get('url')}")
+        self.assertEqual(captured.get("json"), {"x": "hello"},
+                         f"body must contain ONLY requestBody props, got {captured.get('json')}")
+        self.assertNotIn("a", captured.get("json") or {})
+        self.assertNotIn("b", captured.get("json") or {})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivating bug
Calling a non-GET operation whose path has parameters leaked those params into the JSON body. Real-world failure: **Home Assistant `POST /api/services/{domain}/{service}` → HTTP 400**, because the body carried `domain`/`service`.

## Fix (Task A)
The placeholder strip in the low-level dispatch handler ran **only for GET**. After `path.format(**parameters)` substitutes the placeholders into the URL, they were still left in `parameters`, and `request_body = parameters` for POST/PUT/PATCH/DELETE. Dedented the strip so it runs for **all methods**.

**Regression test** (`tests/unit/test_path_params_non_get_body.py`): `POST /widgets/{a}/{b}` with body prop `x` → outbound URL has `a`/`b` substituted **and** JSON body == `{"x": ...}` with no `a`/`b`. (Fails before the fix: `{'a','b','x'} != {'x'}`.)

## Home Assistant example (Task B)
`examples/homeassistant.openapi.json` (+ `homeassistant-claude_desktop_config.json`): generic, secret-free REST slice — `get_config`, `list_states`, `get_state`, `list_services`, `call_service`, `get_history`. `call_service` defines named body props (entity_id, message, title, brightness_pct, color_name, temperature, hvac_mode, code; `additionalProperties: true`) so they surface as tool args. Auth via `SERVER_URL_OVERRIDE` + `EXTRA_HEADERS="Authorization: Bearer ${HA_TOKEN}"`. README example block + results-table row added. This example **requires this fix** (else `call_service` 400s).

## Release (Task C)
Bump 0.3.2 → **0.3.3**; CHANGELOG updated.

## Tests
`163 passed, 27 skipped` (skips are external-API integrations needing creds). No secrets in the diff (token via `${HA_TOKEN}` placeholder).