### PR TITLE
docs: refresh prompts/resources client comparison (0.3.3 sweep)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ The example configurations below were exercised against the live APIs, and the p
 | flyio | 34–35 | apps + machine health | `API_KEY` |
 | slack | 7 (exact dot-path whitelist until #27 fix) | `auth.test` + `postMessage` | `API_KEY` |
 | netbox | 9 (whitelist `/ipam/ip-addresses`) | IPAM write + read | `API_KEY` + `API_AUTH_TYPE=Token` |
-| homeassistant | 6 | `get_config` (200) + `call_service` (light.turn_on, 200) | `SERVER_URL_OVERRIDE` + `API_KEY` (`${HA_TOKEN}`, sent as Bearer) |
+| homeassistant | 21 | `get_config` (200) + `call_service` (light.turn_on, 200) | `SERVER_URL_OVERRIDE` + `API_KEY` (`${HA_TOKEN}`, sent as Bearer) |
 
 ### Client matrix
 
@@ -923,8 +923,13 @@ Tips: set `IGNORE_SSL_TOOLS=true` only if your host serves a self-signed/mismatc
 <details>
 <summary><b>Home Assistant Example</b> — control your smart home; <code>call_service</code> needs the >= 0.3.3 path-param body fix</summary>
 
-Exposes a small generic slice of the Home Assistant REST API: `get_config`, `list_states`,
-`get_state`, `list_services`, `call_service`, `get_history`.
+Exposes a generic slice of the [Home Assistant REST API](https://developers.home-assistant.io/docs/api/rest/)
+(21 operations) — read state (`get_config`, `list_states`, `get_state`, `list_services`,
+`get_history`/`get_history_now`, `get_logbook`, `list_calendars`, `get_calendar_events`,
+`get_camera_image`, `get_error_log`, `list_components`, `list_events`, `get_api_status`) and
+act (`call_service`, `set_state`, `delete_state`, `fire_event`, `render_template`,
+`check_config`, `handle_intent`). HA ships no official OpenAPI spec, so this is hand-rolled
+from the official docs.
 
 #### 1. Verify the OpenAPI specification
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ The example configurations below were exercised against the live APIs, and the p
 | flyio | 34–35 | apps + machine health | `API_KEY` |
 | slack | 7 (exact dot-path whitelist until #27 fix) | `auth.test` + `postMessage` | `API_KEY` |
 | netbox | 9 (whitelist `/ipam/ip-addresses`) | IPAM write + read | `API_KEY` + `API_AUTH_TYPE=Token` |
-| homeassistant | 6 | `get_config` (200) + `call_service` (light.turn_on, 200) | `SERVER_URL_OVERRIDE` + `EXTRA_HEADERS` (`Authorization: Bearer ${HA_TOKEN}`) |
+| homeassistant | 6 | `get_config` (200) + `call_service` (light.turn_on, 200) | `SERVER_URL_OVERRIDE` + `API_KEY` (`${HA_TOKEN}`, sent as Bearer) |
 
 ### Client matrix
 
@@ -943,7 +943,7 @@ curl https://raw.githubusercontent.com/matthewhand/mcp-openapi-proxy/refs/heads/
             "env": {
                 "OPENAPI_SPEC_URL": "https://raw.githubusercontent.com/matthewhand/mcp-openapi-proxy/refs/heads/main/examples/homeassistant.openapi.json",
                 "SERVER_URL_OVERRIDE": "http://homeassistant.local:8123",
-                "EXTRA_HEADERS": "Authorization: Bearer ${HA_TOKEN}"
+                "API_KEY": "${HA_TOKEN}"
             }
         }
     }
@@ -952,7 +952,7 @@ curl https://raw.githubusercontent.com/matthewhand/mcp-openapi-proxy/refs/heads/
 
 Key configuration points:
 - `SERVER_URL_OVERRIDE` — your instance base URL, e.g. `http://homeassistant.local:8123` or `http://<ha-host>:8123`.
-- `HA_TOKEN` — a Home Assistant **long-lived access token** (Profile → Long-Lived Access Tokens), passed via `EXTRA_HEADERS`. Never commit the token; keep it in your environment.
+- `HA_TOKEN` — a Home Assistant **long-lived access token** (Profile → Long-Lived Access Tokens), passed via `API_KEY`; the proxy sends it as `Authorization: Bearer <token>` (its default scheme), so no `EXTRA_HEADERS` needed. Never commit the token; keep it in your environment.
 - `call_service` requires **mcp-openapi-proxy >= 0.3.3**: earlier versions leaked the `{domain}`/`{service}` path params into the JSON body, which Home Assistant rejects with HTTP 400.
 
 #### 3. Testing

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ The example configurations below were exercised against the live APIs, and the p
 | Agent CLI | Model used (live test) | MCP attach mechanism | Tool calls | Prompts/Resources surfaced to model? |
 |---|---|---|---|---|
 | **opencode** | (CLI default) | `~/.config/opencode/opencode.json` `mcp` | ✅ native | **prompts: ✅ (slash) · resources: ✅** — most complete ‖ |
-| Codex | `gpt-5-codex` (OpenAI API) | `codex exec -c mcp_servers.*` | ✅ native | prompts: ❌ (no prompt meta-tools) · resources: ✅ (`read_mcp_resource`) ‖ |
+| Codex | `gpt-5-codex` (OpenAI API) | `codex exec -c mcp_servers.*` | ✅ native | prompts: ❌ low-level · ✅ fastmcp (via `call_function`→`get_prompt`) · resources: ✅ (`read_mcp_resource`) ‖ |
 | Kilocode | `kilo-auto/free` | global `settings/mcp_settings.json` | ✅ native | prompts: ❌ (no prompt mechanism) · resources: ✅ (`access_mcp_resource`) ‖ |
 | Qwen | `agent` group via local LiteLLM gateway | project `.qwen/settings.json` | ✅ native (live invoke auth-blocked) | prompts: ✅ (slash `/summarize_spec`) · resources: ❌ (no client support) ‖ |
 | Gemini | Google OAuth free tier (CLI default model) | project `.gemini/settings.json` `mcpServers` | ✅ native | prompts: interactive slash only · resources: interactive `@` only (neither reaches the model headless) ‖ |
@@ -167,11 +167,17 @@ The example configurations below were exercised against the live APIs, and the p
 > resources. **mcp-openapi-proxy serves all three, advertised by default since 0.3.0.**
 > Whether they reach the model is up to the *client*, and that varies:
 >
-> - **‖ re-verified 2026-06-14 against the published 0.3.0 release** with **no** flags set
->   (validating the default-on advertising), driving each **real client binary**.
+> - **‖ re-verified 2026-06-15 against the published 0.3.3 release** with **no** flags set
+>   (validating the default-on advertising), driving each **real client binary**, in
+>   **both** server modes (low-level and FastMCP simple). Per-client results were the
+>   same across modes except where noted.
 > - **Tools** work on every client tested. **Prompts→model**: opencode & Qwen (slash
 >   commands); Gemini interactive-only. **Resources→model**: opencode, Codex, Kilocode.
->   **opencode is the only client that surfaces all three.** Vibe is tools-only.
+>   **opencode is the only client that surfaces all three** in any mode.
+> - **FastMCP simple mode exception:** a client with no native prompt surface can still
+>   reach prompts through the static `call_function`→`get_prompt` indirection. Observed
+>   with **Codex** (prompts ❌ in low-level, ✅ in FastMCP simple mode). Vibe stays
+>   tools-only regardless of mode.
 > - **‡ unknown** — Letta can't be exercised without standing up a Letta server + model;
 >   left untested rather than guessed.
 > - Every cell on the proxy side was confirmed via a raw stdio handshake (`initialize`

--- a/docs/verification-case-study.md
+++ b/docs/verification-case-study.md
@@ -50,7 +50,7 @@ sane tool count.
 | Client | Model (live test) | MCP attach mechanism | Tool calls | Prompts/resources to model |
 | --- | --- | --- | --- | --- |
 | opencode | (CLI default) | `opencode.json` `mcp` | ✅ native | **prompts: ✅ (slash) · resources: ✅ — most complete** ‖ |
-| Codex | gpt-5-codex | `codex exec -c mcp_servers.*` | ✅ native | prompts: ❌ (no prompt meta-tools) · resources: ✅ (`read_mcp_resource`) ‖ |
+| Codex | gpt-5-codex | `codex exec -c mcp_servers.*` | ✅ native | prompts: ❌ low-level · ✅ fastmcp (via `call_function`→`get_prompt`) · resources: ✅ (`read_mcp_resource`) ‖ |
 | Kilocode | free auto model | global `mcp_settings.json` | ✅ native | prompts: ❌ · resources: ✅ (`access_mcp_resource`) ‖ |
 | Qwen | gateway model group | project `.qwen/settings.json` | ✅ native (live invoke auth-blocked) | prompts: ✅ (slash) · resources: ❌ ‖ |
 | Gemini | Google OAuth tier | project `.gemini/settings.json` | ✅ native | prompts: interactive slash only · resources: interactive `@` only ‖ |
@@ -58,7 +58,12 @@ sane tool count.
 | agy | — | — | ❌ headless can't enable MCP | n/a |
 | Letta (cloud / self-hosted) | Letta Cloud / `PUT /v1/tools/mcp/servers` | streamable-HTTP / stdio | ✅ (prior sweep) | unknown — needs a running Letta server to test ‡ |
 
-*‖ re-verified 2026-06-14 against the **published 0.3.0** release with no flags set (default-on advertising), driving each real client binary. ‡ Letta not exercised — needs a running server + model, not feasible headless. All pre-0.3.0 prompt/resource results were **voided** (measured while advertising defaulted off). Tool-call results were unaffected and stand.*
+*‖ re-verified 2026-06-15 against the **published 0.3.3** release with no flags set (default-on advertising), driving each real client binary in **both** server modes (low-level and FastMCP simple); per-client results matched across modes except Codex prompts (see below). ‡ Letta not exercised — needs a running server + model, not feasible headless. All pre-0.3.0 prompt/resource results were **voided** (measured while advertising defaulted off). Tool-call results were unaffected and stand.*
+
+> **FastMCP-mode prompt access:** in FastMCP simple mode the static `call_function`
+> exposes `get_prompt`/`list_prompts`, so a client with no native prompt surface can still
+> reach prompts that way. Codex shows this: prompts ❌ in low-level mode, ✅ in FastMCP
+> simple mode. Resources behaved the same in both modes for every client.
 
 **Systemic finding:** every CLI tested could call MCP *tools* natively. Surfacing of
 MCP *prompts/resources* to the model is uneven across clients — but read the correction

--- a/examples/homeassistant-claude_desktop_config.json
+++ b/examples/homeassistant-claude_desktop_config.json
@@ -8,7 +8,7 @@
       "env": {
         "OPENAPI_SPEC_URL": "https://raw.githubusercontent.com/matthewhand/mcp-openapi-proxy/refs/heads/main/examples/homeassistant.openapi.json",
         "SERVER_URL_OVERRIDE": "http://homeassistant.local:8123",
-        "EXTRA_HEADERS": "Authorization: Bearer ${HA_TOKEN}"
+        "API_KEY": "${HA_TOKEN}"
       }
     }
   }

--- a/examples/homeassistant.openapi.json
+++ b/examples/homeassistant.openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Home Assistant REST API (example subset)",
     "version": "1.0.0",
-    "description": "Minimal, generic Home Assistant REST API spec for mcp-openapi-proxy. Point SERVER_URL_OVERRIDE at your instance (http://<ha-host>:8123) and authenticate with a long-lived access token via EXTRA_HEADERS=\"Authorization: Bearer ${HA_TOKEN}\". call_service requires the path-parameter body-strip fix (>= 0.3.3)."
+    "description": "Minimal, generic Home Assistant REST API spec for mcp-openapi-proxy. Point SERVER_URL_OVERRIDE at your instance (http://<ha-host>:8123) and authenticate with a long-lived access token via API_KEY=${HA_TOKEN} (the proxy sends it as 'Authorization: Bearer <token>' by default). call_service requires the path-parameter body-strip fix (>= 0.3.3)."
   },
   "servers": [
     { "url": "http://homeassistant.local:8123" }

--- a/examples/homeassistant.openapi.json
+++ b/examples/homeassistant.openapi.json
@@ -1,18 +1,46 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "title": "Home Assistant REST API (example subset)",
-    "version": "1.0.0",
-    "description": "Minimal, generic Home Assistant REST API spec for mcp-openapi-proxy. Point SERVER_URL_OVERRIDE at your instance (http://<ha-host>:8123) and authenticate with a long-lived access token via API_KEY=${HA_TOKEN} (the proxy sends it as 'Authorization: Bearer <token>' by default). call_service requires the path-parameter body-strip fix (>= 0.3.3)."
+    "title": "Home Assistant REST API (example)",
+    "version": "1.1.0",
+    "description": "Generic Home Assistant REST API spec for mcp-openapi-proxy, modelled on the official docs at https://developers.home-assistant.io/docs/api/rest/ (HA ships no official OpenAPI spec). Point SERVER_URL_OVERRIDE at your instance (http://<ha-host>:8123) and authenticate with a long-lived access token via API_KEY=${HA_TOKEN} (the proxy sends it as 'Authorization: Bearer <token>' by default). POST operations with path parameters (call_service, set_state, fire_event) require the path-parameter body-strip fix (>= 0.3.3)."
   },
   "servers": [
     { "url": "http://homeassistant.local:8123" }
   ],
   "paths": {
+    "/api/": {
+      "get": {
+        "operationId": "get_api_status",
+        "summary": "Check the API is up and running",
+        "responses": { "200": { "description": "OK" } }
+      }
+    },
     "/api/config": {
       "get": {
         "operationId": "get_config",
         "summary": "Get the Home Assistant configuration",
+        "responses": { "200": { "description": "OK" } }
+      }
+    },
+    "/api/components": {
+      "get": {
+        "operationId": "list_components",
+        "summary": "List the loaded components",
+        "responses": { "200": { "description": "OK" } }
+      }
+    },
+    "/api/events": {
+      "get": {
+        "operationId": "list_events",
+        "summary": "List the available events and listener counts",
+        "responses": { "200": { "description": "OK" } }
+      }
+    },
+    "/api/error_log": {
+      "get": {
+        "operationId": "get_error_log",
+        "summary": "Retrieve all errors logged during the current session",
         "responses": { "200": { "description": "OK" } }
       }
     },
@@ -29,6 +57,41 @@
         "summary": "Get the state of one entity",
         "parameters": [
           { "name": "entity_id", "in": "path", "required": true, "schema": { "type": "string" }, "description": "Entity id, e.g. light.kitchen" }
+        ],
+        "responses": { "200": { "description": "OK" } }
+      },
+      "post": {
+        "operationId": "set_state",
+        "summary": "Create or update the state of an entity (does not talk to the device)",
+        "parameters": [
+          { "name": "entity_id", "in": "path", "required": true, "schema": { "type": "string" }, "description": "Entity id, e.g. sensor.kitchen_temperature" }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["state"],
+                "properties": {
+                  "state": { "type": "string", "description": "New state value" },
+                  "attributes": { "type": "object", "description": "Optional state attributes", "additionalProperties": true }
+                },
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "Updated existing state" },
+          "201": { "description": "Created new state" }
+        }
+      },
+      "delete": {
+        "operationId": "delete_state",
+        "summary": "Delete an entity's state",
+        "parameters": [
+          { "name": "entity_id", "in": "path", "required": true, "schema": { "type": "string" }, "description": "Entity id to remove" }
         ],
         "responses": { "200": { "description": "OK" } }
       }
@@ -73,13 +136,145 @@
         "responses": { "200": { "description": "OK" } }
       }
     },
+    "/api/events/{event_type}": {
+      "post": {
+        "operationId": "fire_event",
+        "summary": "Fire an event with optional event data",
+        "parameters": [
+          { "name": "event_type", "in": "path", "required": true, "schema": { "type": "string" }, "description": "Event type, e.g. my_custom_event" }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "description": "Arbitrary event data.",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "responses": { "200": { "description": "OK" } }
+      }
+    },
+    "/api/history/period": {
+      "get": {
+        "operationId": "get_history_now",
+        "summary": "Get state history (defaults to the last day)",
+        "parameters": [
+          { "name": "filter_entity_id", "in": "query", "required": true, "schema": { "type": "string" }, "description": "Comma-separated entity ids to include, e.g. sensor.temp,light.kitchen" },
+          { "name": "end_time", "in": "query", "required": false, "schema": { "type": "string" }, "description": "URL-encoded ISO 8601 end of the period" },
+          { "name": "minimal_response", "in": "query", "required": false, "schema": { "type": "boolean" }, "description": "Return only last_changed and state" },
+          { "name": "no_attributes", "in": "query", "required": false, "schema": { "type": "boolean" }, "description": "Skip returning attributes" },
+          { "name": "significant_changes_only", "in": "query", "required": false, "schema": { "type": "boolean" }, "description": "Only return significant state changes" }
+        ],
+        "responses": { "200": { "description": "OK" } }
+      }
+    },
     "/api/history/period/{timestamp}": {
       "get": {
         "operationId": "get_history",
         "summary": "Get state history starting at a timestamp",
         "parameters": [
-          { "name": "timestamp", "in": "path", "required": true, "schema": { "type": "string" }, "description": "ISO 8601 start time, e.g. 2024-01-01T00:00:00+00:00" }
+          { "name": "timestamp", "in": "path", "required": true, "schema": { "type": "string" }, "description": "ISO 8601 start time, e.g. 2024-01-01T00:00:00+00:00" },
+          { "name": "filter_entity_id", "in": "query", "required": true, "schema": { "type": "string" }, "description": "Comma-separated entity ids to include, e.g. sensor.temp,light.kitchen" },
+          { "name": "end_time", "in": "query", "required": false, "schema": { "type": "string" }, "description": "URL-encoded ISO 8601 end of the period" },
+          { "name": "minimal_response", "in": "query", "required": false, "schema": { "type": "boolean" }, "description": "Return only last_changed and state" },
+          { "name": "no_attributes", "in": "query", "required": false, "schema": { "type": "boolean" }, "description": "Skip returning attributes" },
+          { "name": "significant_changes_only", "in": "query", "required": false, "schema": { "type": "boolean" }, "description": "Only return significant state changes" }
         ],
+        "responses": { "200": { "description": "OK" } }
+      }
+    },
+    "/api/logbook/{timestamp}": {
+      "get": {
+        "operationId": "get_logbook",
+        "summary": "Get logbook entries starting at a timestamp",
+        "parameters": [
+          { "name": "timestamp", "in": "path", "required": true, "schema": { "type": "string" }, "description": "ISO 8601 start time" },
+          { "name": "entity", "in": "query", "required": false, "schema": { "type": "string" }, "description": "Filter on a single entity id" },
+          { "name": "end_time", "in": "query", "required": false, "schema": { "type": "string" }, "description": "URL-encoded ISO 8601 end of the period" }
+        ],
+        "responses": { "200": { "description": "OK" } }
+      }
+    },
+    "/api/calendars": {
+      "get": {
+        "operationId": "list_calendars",
+        "summary": "List the calendar entities",
+        "responses": { "200": { "description": "OK" } }
+      }
+    },
+    "/api/calendars/{calendar_entity_id}": {
+      "get": {
+        "operationId": "get_calendar_events",
+        "summary": "Get calendar events between two times",
+        "parameters": [
+          { "name": "calendar_entity_id", "in": "path", "required": true, "schema": { "type": "string" }, "description": "Calendar entity id, e.g. calendar.home" },
+          { "name": "start", "in": "query", "required": true, "schema": { "type": "string" }, "description": "URL-encoded ISO 8601 start time" },
+          { "name": "end", "in": "query", "required": true, "schema": { "type": "string" }, "description": "URL-encoded ISO 8601 end time" }
+        ],
+        "responses": { "200": { "description": "OK" } }
+      }
+    },
+    "/api/camera_proxy/{camera_entity_id}": {
+      "get": {
+        "operationId": "get_camera_image",
+        "summary": "Get the current image from a camera entity",
+        "parameters": [
+          { "name": "camera_entity_id", "in": "path", "required": true, "schema": { "type": "string" }, "description": "Camera entity id, e.g. camera.front_door" }
+        ],
+        "responses": { "200": { "description": "OK" } }
+      }
+    },
+    "/api/template": {
+      "post": {
+        "operationId": "render_template",
+        "summary": "Render a Home Assistant Jinja2 template",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["template"],
+                "properties": {
+                  "template": { "type": "string", "description": "Template string, e.g. {{ states('sensor.temperature') }}" }
+                }
+              }
+            }
+          }
+        },
+        "responses": { "200": { "description": "Rendered template (text/plain)" } }
+      }
+    },
+    "/api/config/core/check_config": {
+      "post": {
+        "operationId": "check_config",
+        "summary": "Trigger a check of configuration.yaml",
+        "responses": { "200": { "description": "OK" } }
+      }
+    },
+    "/api/intent/handle": {
+      "post": {
+        "operationId": "handle_intent",
+        "summary": "Handle an intent",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["name"],
+                "properties": {
+                  "name": { "type": "string", "description": "Intent name, e.g. SetTimer" },
+                  "data": { "type": "object", "description": "Intent slot data", "additionalProperties": true }
+                }
+              }
+            }
+          }
+        },
         "responses": { "200": { "description": "OK" } }
       }
     }

--- a/examples/netlify-claude_desktop_config.json
+++ b/examples/netlify-claude_desktop_config.json
@@ -1,0 +1,16 @@
+{
+  "mcpServers": {
+    "netlify": {
+      "command": "uvx",
+      "args": [
+        "mcp-openapi-proxy"
+      ],
+      "env": {
+        "OPENAPI_SPEC_URL": "https://open-api.netlify.com/swagger.json",
+        "OPENAPI_SPEC_FORMAT": "json",
+        "TOOL_WHITELIST": "/sites,/deploys/{deploy_id},/builds/{build_id}",
+        "API_KEY": "${NETLIFY_API_KEY}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Refreshes the **prompts & resources** per-client comparison (README client matrix + verification case study) with the 0.3.3 real-binary sweep.

Key updates:
- Re-verified against **published 0.3.3**, both server modes (low-level + FastMCP simple).
- **New nuance:** FastMCP simple mode's `call_function`→`get_prompt` lets a client with no native prompt surface still reach prompts. **Codex: prompts ❌ low-level, ✅ fastmcp.**
- **opencode** remains the only client surfacing all three (tools+prompts+resources) natively. Resources behaved the same across modes for every client.

**Docs-only. No version bump** — merging to `main` auto-publishes, so add a version bump (e.g. 0.3.4) at release time, or merge bundled with the next code change. **Held for review; nothing publishes from this PR.**