### PR TITLE
fix(examples): use live Render OpenAPI spec URL in sample_mcpServers.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- `render` example: point `sample_mcpServers.json` at Render's live OpenAPI spec
+  (`https://api-docs.render.com/openapi/render-public-api-1.json`). The previous
+  id-based URL 302-redirects to `/404`, so the example registered **zero tools**.
+  Now matches the URL already used in `README.md` and
+  `examples/render-claude_desktop_config.json`.
+
 ## 0.3.3
 
 ### Fixed

--- a/sample_mcpServers.json
+++ b/sample_mcpServers.json
@@ -27,7 +27,7 @@
       "command": "uvx",
       "args": ["mcp-openapi-proxy"],
       "env": {
-        "OPENAPI_SPEC_URL": "https://api-docs.render.com/openapi/6140fb3daeae351056086186",
+        "OPENAPI_SPEC_URL": "https://api-docs.render.com/openapi/render-public-api-1.json",
         "TOOL_WHITELIST": "/services,/maintenance",
         "API_KEY": "your_render_token_here"
       }


### PR DESCRIPTION
## Problem
The `render` example in `sample_mcpServers.json` points at an id-based spec URL
(`https://api-docs.render.com/openapi/6140fb3daeae351056086186`) that now **302-redirects to `/404`**.
A user copying this config gets a render MCP server with **zero tools** (spec fetch fails silently).

## Fix
Switch to Render's current published spec:
`https://api-docs.render.com/openapi/render-public-api-1.json`

This is the **same URL already used** elsewhere in the repo — `README.md` (3 places) and
`examples/render-claude_desktop_config.json` — so this just brings `sample_mcpServers.json`
back in line; no behavioural change beyond making the example work.

## Verification
- Dead URL: `curl -sIL .../6140fb3...` → `302` → `/404` (HTML).
- New URL: `200`, `application/json`, **124 paths** including `/services` and `/maintenance`
  (the example's `TOOL_WHITELIST`).
- Ran `uvx mcp-openapi-proxy` with the new URL → **52 tools** registered and listable via `tools/list`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)