### PR TITLE
Support FastMCP OpenAPI methods

### DIFF
--- a/mcp_openapi_proxy/server_fastmcp.py
+++ b/mcp_openapi_proxy/server_fastmcp.py
@@ -35,6 +35,22 @@ spec = None  # Global spec for resources
 # names deduplicated after TOOL_NAME_MAX_LENGTH truncation (issue #11) remain
 # callable via call_function.
 _FUNCTION_OPERATIONS: Dict[str, Dict] = {}
+SUPPORTED_OPENAPI_METHODS = (
+    "get",
+    "post",
+    "put",
+    "delete",
+    "patch",
+    "options",
+    "head",
+    "trace",
+)
+BODYLESS_OPENAPI_METHODS = (
+    "get",
+    "head",
+    "options",
+    "trace",
+)
 
 
 # --- Native MCP prompts & resources for FastMCP/simple mode ---
@@ -74,7 +90,7 @@ def _spec_file_resource() -> str:
 
 @mcp.prompt(name="summarize_spec", description="Summarizes the OpenAPI specification")
 def _summarize_spec_prompt() -> str:
-    return ("This OpenAPI spec defines endpoints, parameters, and responses—a "
+    return ("This OpenAPI spec defines endpoints, parameters, and responses - a "
             "blueprint for developers to integrate effectively.")
 
 
@@ -145,7 +161,7 @@ def list_functions(*, env_key: str = "OPENAPI_SPEC_URL") -> str:
             if not method:
                 logger.debug(f"Method is empty for {path}")
                 continue
-            if method.lower() not in ["get", "post", "put", "delete", "patch"]:
+            if method.lower() not in SUPPORTED_OPENAPI_METHODS:
                 logger.debug(f"Skipping unsupported method: {method}")
                 continue
             raw_name = f"{method.upper()} {path}"
@@ -320,7 +336,7 @@ def call_function(*, function_name: str, parameters: Optional[Dict] = None, env_
         logger.debug(f"Checking path: {path}")
         for method, operation in path_item.items():
             logger.debug(f"Checking method: {method} for path: {path}")
-            if method.lower() not in ["get", "post", "put", "delete", "patch"]:
+            if method.lower() not in SUPPORTED_OPENAPI_METHODS:
                 logger.debug(f"Skipping unsupported method: {method}")
                 continue
             raw_name = f"{method.upper()} {path}"
@@ -354,6 +370,7 @@ def call_function(*, function_name: str, parameters: Optional[Dict] = None, env_
 
     operation = function_def["operation"]
     operation["method"] = function_def["method"]
+    method_lower = function_def["method"].lower()
     headers = handle_auth(operation)
     additional_headers = get_additional_headers()
     headers = {**headers, **additional_headers}
@@ -361,7 +378,7 @@ def call_function(*, function_name: str, parameters: Optional[Dict] = None, env_
         parameters = {}
     parameters = strip_parameters(parameters)
     logger.debug(f"Parameters after strip: {parameters}")
-    if function_def["method"] != "GET":
+    if method_lower not in BODYLESS_OPENAPI_METHODS:
         headers["Content-Type"] = "application/json"
 
     if not is_tool_whitelisted(function_def["path"]):
@@ -407,7 +424,7 @@ def call_function(*, function_name: str, parameters: Optional[Dict] = None, env_
     if isinstance(parameters, dict):
         if "stream" in parameters and parameters["stream"]:
             del parameters["stream"]
-        if function_def["method"] == "GET":
+        if method_lower in BODYLESS_OPENAPI_METHODS:
             request_params = parameters
         else:
             request_body = parameters
@@ -425,8 +442,8 @@ def call_function(*, function_name: str, parameters: Optional[Dict] = None, env_
             method=function_def["method"],
             url=api_url,
             headers=headers,
-            params=request_params if function_def["method"] == "GET" else None,
-            json=request_body if function_def["method"] != "GET" else None,
+            params=request_params if request_params else None,
+            json=request_body,
             verify=verify_ssl_tools
         )
         response.raise_for_status()

--- a/tests/unit/test_input_schema_generation.py
+++ b/tests/unit/test_input_schema_generation.py
@@ -202,6 +202,113 @@ class TestInputSchemaGeneration(unittest.TestCase):
         self.assertEqual(ids_prop["type"], "array")
         self.assertEqual(ids_prop.get("items"), {"type": "string"})
 
+    def test_fastmcp_registers_all_openapi_methods(self):
+        import json
+        import os
+        from mcp_openapi_proxy import server_fastmcp
+
+        spec = {
+            "openapi": "3.0.0",
+            "servers": [{"url": "https://dummy-base.com"}],
+            "paths": {
+                "/diagnostics": {
+                    "head": {
+                        "summary": "Check diagnostics metadata",
+                        "responses": {"200": {"description": "OK"}},
+                    },
+                    "options": {
+                        "summary": "List diagnostics capabilities",
+                        "responses": {"204": {"description": "No Content"}},
+                    },
+                    "trace": {
+                        "summary": "Trace diagnostics request",
+                        "responses": {"200": {"description": "OK"}},
+                    },
+                }
+            },
+        }
+        original_fetch = server_fastmcp.fetch_openapi_spec
+        server_fastmcp.fetch_openapi_spec = lambda url: spec
+        os.environ["OPENAPI_SPEC_URL"] = "http://dummy_url_methods"
+        try:
+            result = json.loads(server_fastmcp.list_functions(env_key="OPENAPI_SPEC_URL"))
+        finally:
+            server_fastmcp.fetch_openapi_spec = original_fetch
+            os.environ.pop("OPENAPI_SPEC_URL", None)
+
+        methods = {tool["method"] for tool in result if tool.get("path") == "/diagnostics"}
+
+        self.assertEqual(methods, {"HEAD", "OPTIONS", "TRACE"})
+
+    def test_fastmcp_bodyless_methods_use_query_params(self):
+        import json
+        import os
+        from mcp_openapi_proxy import server_fastmcp
+
+        spec = {
+            "openapi": "3.0.0",
+            "servers": [{"url": "https://dummy-base.com"}],
+            "paths": {
+                "/diagnostics": {
+                    "head": {
+                        "summary": "Check diagnostics metadata",
+                        "parameters": [
+                            {
+                                "name": "include",
+                                "in": "query",
+                                "required": False,
+                                "schema": {"type": "string"},
+                            },
+                        ],
+                        "responses": {"200": {"description": "OK"}},
+                    },
+                },
+            },
+        }
+        captured = {}
+
+        class Response:
+            text = json.dumps({"ok": True})
+
+            def raise_for_status(self):
+                pass
+
+        def fake_request(method, url, **kwargs):
+            captured["method"] = method
+            captured["url"] = url
+            captured["params"] = kwargs.get("params")
+            captured["json"] = kwargs.get("json")
+            captured["headers"] = kwargs.get("headers")
+            return Response()
+
+        original_fetch = server_fastmcp.fetch_openapi_spec
+        original_request = server_fastmcp.requests.request
+        original_whitelist = server_fastmcp.is_tool_whitelisted
+        server_fastmcp.fetch_openapi_spec = lambda url: spec
+        server_fastmcp.requests.request = fake_request
+        server_fastmcp.is_tool_whitelisted = lambda path: True
+        os.environ["OPENAPI_SPEC_URL"] = "http://dummy_url_bodyless"
+        try:
+            result = json.loads(
+                server_fastmcp.call_function(
+                    function_name="head_diagnostics",
+                    parameters={"include": "headers"},
+                    env_key="OPENAPI_SPEC_URL",
+                )
+            )
+        finally:
+            server_fastmcp.fetch_openapi_spec = original_fetch
+            server_fastmcp.requests.request = original_request
+            server_fastmcp.is_tool_whitelisted = original_whitelist
+            os.environ.pop("OPENAPI_SPEC_URL", None)
+
+        self.assertEqual(result, {"ok": True})
+        self.assertEqual(captured["method"], "HEAD")
+        self.assertEqual(captured["url"], "https://dummy-base.com/diagnostics")
+        self.assertEqual(captured["params"], {"include": "headers"})
+        self.assertIsNone(captured["json"])
+        self.assertNotIn("Content-Type", captured["headers"])
+
     def test_input_schema_contents(self):
         # Ensure that one tool is registered for the endpoint using the returned tools list directly
         registered_tools = register_functions(self.dummy_spec)


### PR DESCRIPTION
## Summary
- Share the FastMCP OpenAPI method allowlist with `HEAD`, `OPTIONS`, and `TRACE`.
- Keep fallback lookup aligned with `list_functions`.
- Add a unit test proving FastMCP discovers those operation methods.

## Why
OpenAPI allows these methods, and the low-level registration path already handles them. FastMCP skipped them during discovery, so valid operations were unavailable.

## Validation
- `python -m pytest tests/unit/test_input_schema_generation.py -q`
- `python -m pytest tests/unit -q`
- `python -m py_compile mcp_openapi_proxy/server_fastmcp.py tests/unit/test_input_schema_generation.py`
- `python -m pip check`
- `python -m build`
- `git diff --check`
