### PR TITLE
Add Xquik example and fix FastMCP helpers

### DIFF
--- a/examples/xquik-claude_desktop_config.json
+++ b/examples/xquik-claude_desktop_config.json
@@ -1,0 +1,17 @@
+{
+  "mcpServers": {
+    "xquik": {
+      "command": "uvx",
+      "args": [
+        "mcp-openapi-proxy"
+      ],
+      "env": {
+        "OPENAPI_SPEC_URL": "https://xquik.com/openapi.json",
+        "TOOL_WHITELIST": "/api/v1/x/tweets/search",
+        "API_KEY": "your-xquik-api-key",
+        "API_AUTH_TYPE": "api-key",
+        "API_AUTH_HEADER": "x-api-key"
+      }
+    }
+  }
+}

--- a/mcp_openapi_proxy/server_fastmcp.py
+++ b/mcp_openapi_proxy/server_fastmcp.py
@@ -239,27 +239,6 @@ def list_functions(*, env_key: str = "OPENAPI_SPEC_URL") -> str:
         "inputSchema": {"type": "object", "properties": {"name": {"type": "string", "description": "Prompt name"}}, "required": ["name"], "additionalProperties": False}
     }
     logger.debug(f"Discovered {len(functions)} functions from the OpenAPI specification.")
-    if "get_tasks_id" not in functions:
-        functions["get_tasks_id"] = {
-            "name": "get_tasks_id",
-            "description": "Get tasks",
-            "path": "/users/{user_id}/tasks",
-            "method": "GET",
-            "operationId": "get_users_tasks",
-            "original_name": "GET /users/{user_id}/tasks",
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "user_id": {
-                        "type": "string",
-                        "description": "Path parameter user_id"
-                    }
-                },
-                "required": ["user_id"],
-                "additionalProperties": False
-            }
-        }
-        logger.debug("Forced registration of get_tasks_id for testing.")
     logger.debug(f"Functions list: {list(functions.values())}")
     return json.dumps(list(functions.values()), indent=2)
 

--- a/mcp_openapi_proxy/server_fastmcp.py
+++ b/mcp_openapi_proxy/server_fastmcp.py
@@ -125,8 +125,7 @@ def list_functions(*, env_key: str = "OPENAPI_SPEC_URL") -> str:
     paths = spec.get("paths", {})
     logger.debug(f"Paths extracted from spec: {list(paths.keys())}")
     if not paths:
-        logger.debug("No paths found in spec.")
-        return json.dumps([])
+        logger.debug("No paths found in spec; registering native helper tools only.")
     functions = {}
     _FUNCTION_OPERATIONS.clear()
     for path, path_item in paths.items():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import importlib
 import pytest
 import sys
 repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
@@ -21,10 +22,12 @@ def reset_env_and_module(request):
         if key.startswith("OPENAPI_SPEC_URL"):
             del os.environ[key]
     os.environ["DEBUG"] = "true"
-    # Reload server_fastmcp to reset tools implicitly
+    # Reload the existing module object so functions imported by test modules
+    # continue to share the patched module globals.
     if 'mcp_openapi_proxy.server_fastmcp' in sys.modules:
-        del sys.modules['mcp_openapi_proxy.server_fastmcp']
-    import mcp_openapi_proxy.server_fastmcp  # Fresh import re-registers tools
+        importlib.reload(sys.modules['mcp_openapi_proxy.server_fastmcp'])
+    else:
+        import mcp_openapi_proxy.server_fastmcp
     yield env_key
     # Restore original env
     os.environ.clear()

--- a/tests/integration/test_xquik_example_config.py
+++ b/tests/integration/test_xquik_example_config.py
@@ -1,0 +1,23 @@
+import json
+from pathlib import Path
+
+import requests
+
+
+def test_xquik_example_config_points_to_search_openapi():
+    config_path = Path("examples/xquik-claude_desktop_config.json")
+    config = json.loads(config_path.read_text())
+
+    env = config["mcpServers"]["xquik"]["env"]
+    assert env["OPENAPI_SPEC_URL"] == "https://xquik.com/openapi.json"
+    assert env["TOOL_WHITELIST"] == "/api/v1/x/tweets/search"
+    assert env["API_AUTH_TYPE"] == "api-key"
+    assert env["API_AUTH_HEADER"] == "x-api-key"
+
+    response = requests.get(env["OPENAPI_SPEC_URL"], timeout=10)
+    response.raise_for_status()
+    spec = response.json()
+
+    assert spec["openapi"].startswith("3.")
+    assert spec["info"]["title"] == "Xquik API"
+    assert "/api/v1/x/tweets/search" in spec["paths"]

--- a/tests/integration/test_xquik_example_config.py
+++ b/tests/integration/test_xquik_example_config.py
@@ -1,11 +1,13 @@
 import json
 from pathlib import Path
 
+import pytest
 import requests
 
 from mcp_openapi_proxy.openapi import register_functions
 
 
+@pytest.mark.integration
 def test_xquik_example_config_points_to_search_openapi(monkeypatch):
     config_path = Path("examples/xquik-claude_desktop_config.json")
     config = json.loads(config_path.read_text())

--- a/tests/integration/test_xquik_example_config.py
+++ b/tests/integration/test_xquik_example_config.py
@@ -3,8 +3,10 @@ from pathlib import Path
 
 import requests
 
+from mcp_openapi_proxy.openapi import register_functions
 
-def test_xquik_example_config_points_to_search_openapi():
+
+def test_xquik_example_config_points_to_search_openapi(monkeypatch):
     config_path = Path("examples/xquik-claude_desktop_config.json")
     config = json.loads(config_path.read_text())
 
@@ -21,3 +23,7 @@ def test_xquik_example_config_points_to_search_openapi():
     assert spec["openapi"].startswith("3.")
     assert spec["info"]["title"] == "Xquik API"
     assert "/api/v1/x/tweets/search" in spec["paths"]
+
+    monkeypatch.setenv("TOOL_WHITELIST", env["TOOL_WHITELIST"])
+    tools = register_functions(spec)
+    assert any(tool.name == "get_v1_x_tweets_search" for tool in tools)

--- a/tests/unit/test_prompts.py
+++ b/tests/unit/test_prompts.py
@@ -24,7 +24,7 @@ def test_lowlevel_get_prompt_valid(mock_env):
     assert "blueprint" in result.messages[0].content.text, "Expected 'blueprint' in prompt response"
 
 def test_fastmcp_list_prompts(mock_env):
-    with patch('mcp_openapi_proxy.utils.fetch_openapi_spec', return_value={"paths": {}}):
+    with patch('mcp_openapi_proxy.server_fastmcp.fetch_openapi_spec', return_value={"paths": {}}):
         tools_json = list_functions(env_key="OPENAPI_SPEC_URL")
         tools = json.loads(tools_json)
         assert any(t["name"] == "list_prompts" for t in tools), "list_prompts not found"

--- a/tests/unit/test_resources.py
+++ b/tests/unit/test_resources.py
@@ -64,6 +64,7 @@ def test_fastmcp_list_resources(mock_env):
         tools_json = list_functions(env_key="OPENAPI_SPEC_URL")
         tools = json.loads(tools_json)
         assert any(item["name"] == "list_resources" for item in tools), "list_resources not found"
+        assert not any(item["name"] == "get_tasks_id" for item in tools), "pathless spec exposed a synthetic endpoint"
         result = call_function(function_name="list_resources", parameters={}, env_key="OPENAPI_SPEC_URL")
         resources = json.loads(result)
         assert len(resources) == 1, "Expected one resource"


### PR DESCRIPTION
## Summary

- Add a Claude Desktop example for Xquik's public OpenAPI document.
- Limit the example to tweet search with `x-api-key` header auth.
- Verify the live specification registers the Xquik search tool.
- Keep native FastMCP prompt and resource helpers for pathless specifications.
- Remove the synthetic, uncallable `get_tasks_id` endpoint.
- Reload the existing test module so patches reach imported functions.

## Independent Fix

A valid OpenAPI document with no paths returned before native FastMCP helpers were registered. Continuing helper registration exposed an older synthetic endpoint that no specification defined. The repair keeps real prompt and resource helpers while removing that uncallable endpoint.

## Validation

- `uv run pytest tests/unit`: 141 passed
- `uv run pytest -m 'not integration'`: 157 passed, 10 skipped, 24 deselected
- `uv run pytest tests/integration/test_xquik_example_config.py`: 1 passed
- `uv run pytest`: 162 passed, 29 skipped
- `uv build`: passed
- `git diff --check`: passed

All 3 review threads are resolved. The latest Codex review found no major issues. GitHub's Python Tests run is waiting for maintainer approval and created 0 jobs; the equivalent local unit suite passes.
