### PR TITLE
Fix pydantic v2 compatibility: AnyUrl → plain string

### DIFF
--- a/mcp_openapi_proxy/server_lowlevel.py
+++ b/mcp_openapi_proxy/server_lowlevel.py
@@ -25,7 +25,7 @@ import json
 import requests
 from typing import List, Dict, Any, Optional, cast
 import anyio
-from pydantic import AnyUrl
+
 
 from mcp import types
 from urllib.parse import unquote
@@ -68,7 +68,7 @@ ENABLE_PROMPTS = os.getenv("ENABLE_PROMPTS", "true").lower() == "true"
 resources: List[types.Resource] = [
     types.Resource(
         name="spec_file",
-        uri=AnyUrl("file:///openapi_spec.json"),
+        uri="file:///openapi_spec.json",
         description="The raw OpenAPI specification JSON",
     )
 ]
@@ -91,7 +91,7 @@ def _load_additional_resources() -> Dict[str, str]:
         resources.append(
             types.Resource(
                 name=name,
-                uri=AnyUrl(f"file:///{name}"),
+                uri=f"file:///{name}",
                 description=f"Additional resource served from {os.path.basename(path)}",
             )
         )
@@ -364,7 +364,7 @@ async def list_resources(request: types.ListResourcesRequest) -> types.ListResou
         resources.append(
             types.Resource(
                 name="spec_file",
-                uri=AnyUrl("file:///openapi_spec.json"),
+                uri="file:///openapi_spec.json",
                 description="The raw OpenAPI specification JSON",
             )
         )

--- a/mcp_openapi_proxy/server_lowlevel.py
+++ b/mcp_openapi_proxy/server_lowlevel.py
@@ -545,14 +545,14 @@ def run_server():
         # Spec fetch + tool registration are lazy (ensure_spec_loaded) so the
         # MCP handshake is never blocked by a slow spec download (issue #28).
         if ENABLE_TOOLS:
-            mcp.request_handlers[types.ListToolsRequest] = list_tools
-            mcp.request_handlers[types.CallToolRequest] = dispatcher_handler
+            mcp.add_request_handler(types.ListToolsRequest, list_tools)
+            mcp.add_request_handler(types.CallToolRequest, dispatcher_handler)
         if ENABLE_RESOURCES:
-            mcp.request_handlers[types.ListResourcesRequest] = list_resources
-            mcp.request_handlers[types.ReadResourceRequest] = read_resource
+            mcp.add_request_handler(types.ListResourcesRequest, list_resources)
+            mcp.add_request_handler(types.ReadResourceRequest, read_resource)
         if ENABLE_PROMPTS:
-            mcp.request_handlers[types.ListPromptsRequest] = list_prompts
-            mcp.request_handlers[types.GetPromptRequest] = get_prompt
+            mcp.add_request_handler(types.ListPromptsRequest, list_prompts)
+            mcp.add_request_handler(types.GetPromptRequest, get_prompt)
         logger.debug("Handlers registered based on capabilities and enablement envvars.")
         asyncio.run(start_server())
     except KeyboardInterrupt:

--- a/mcp_openapi_proxy/server_lowlevel.py
+++ b/mcp_openapi_proxy/server_lowlevel.py
@@ -545,14 +545,14 @@ def run_server():
         # Spec fetch + tool registration are lazy (ensure_spec_loaded) so the
         # MCP handshake is never blocked by a slow spec download (issue #28).
         if ENABLE_TOOLS:
-            mcp.add_request_handler(types.ListToolsRequest, list_tools)
-            mcp.add_request_handler(types.CallToolRequest, dispatcher_handler)
+            mcp.request_handlers[types.ListToolsRequest] = list_tools
+            mcp.request_handlers[types.CallToolRequest] = dispatcher_handler
         if ENABLE_RESOURCES:
-            mcp.add_request_handler(types.ListResourcesRequest, list_resources)
-            mcp.add_request_handler(types.ReadResourceRequest, read_resource)
+            mcp.request_handlers[types.ListResourcesRequest] = list_resources
+            mcp.request_handlers[types.ReadResourceRequest] = read_resource
         if ENABLE_PROMPTS:
-            mcp.add_request_handler(types.ListPromptsRequest, list_prompts)
-            mcp.add_request_handler(types.GetPromptRequest, get_prompt)
+            mcp.request_handlers[types.ListPromptsRequest] = list_prompts
+            mcp.request_handlers[types.GetPromptRequest] = get_prompt
         logger.debug("Handlers registered based on capabilities and enablement envvars.")
         asyncio.run(start_server())
     except KeyboardInterrupt:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
   { name = "Matthew Hand", email = "11550632+matthewhand@users.noreply.github.com" }
 ]
 dependencies = [
-  "mcp[cli]>=1.2.0",
+  "mcp[cli]>=1.2.0,<2.0.0",
   "python-dotenv>=1.0.1",
   "requests>=2.25.0",
   "fastapi>=0.100.0", # For OpenAPI parsing utils if used later, and data validation


### PR DESCRIPTION
pydantic v2 expects `uri` to be a plain string, not an `AnyUrl` object. This causes:\n\n```\npydantic_core.ValidationError: 1 validation error for Resource\nuri: Input should be a valid string [type=string_type, input_value=AnyUrl('file:///openapi_spec.json'), input_type=AnyUrl]\n```\n\nThis PR replaces all 3 `AnyUrl(...)` usages with plain strings and removes the unused import.