### PR TITLE
fix(deps): pin mcp to 1.x — mcp 2.x crashes both server modes on fresh install (0.3.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,25 @@
 # Changelog
 
-## Unreleased
+## 0.3.4
 
 ### Fixed
+- **Fresh-install crash:** the unpinned `mcp[cli]>=1.2.0` dependency began resolving
+  to mcp 2.x, which breaks both server modes at import time — FastMCP mode because
+  `mcp.server.fastmcp` was removed (renamed to `MCPServer`), and low-level mode
+  because `types.Resource.uri` changed from `AnyUrl` to `str`, failing the
+  module-level `Resource` construction. Pinned to the known-good 1.x line
+  (`mcp[cli]>=1.2.0,<2`). Dev environments were unaffected (`uv.lock` pins 1.2.1);
+  only fresh `pip install mcp-openapi-proxy` hit it.
 - `render` example: point `sample_mcpServers.json` at Render's live OpenAPI spec
   (`https://api-docs.render.com/openapi/render-public-api-1.json`). The previous
   id-based URL 302-redirects to `/404`, so the example registered **zero tools**.
   Now matches the URL already used in `README.md` and
   `examples/render-claude_desktop_config.json`.
+
+### Tests
+- Regression test (`tests/unit/test_mcp_dependency_pin.py`): asserts the installed
+  mcp is 1.x, that the declared dependency excludes 2.x, and that both server
+  modes import successfully against the pinned dep.
 
 ## 0.3.3
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,14 +5,16 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "mcp-openapi-proxy"
 requires-python = ">=3.10"
-version = "0.3.3"
+version = "0.3.4"
 description = "MCP server for exposing OpenAPI specifications as MCP tools."
 readme = "README.md"
 authors = [
   { name = "Matthew Hand", email = "11550632+matthewhand@users.noreply.github.com" }
 ]
 dependencies = [
-  "mcp[cli]>=1.2.0",
+  # mcp 2.x is a breaking rewrite (FastMCP renamed to MCPServer, types.Resource.uri
+  # became str, ...); both server modes crash on import against it. Pin to 1.x.
+  "mcp[cli]>=1.2.0,<2",
   "python-dotenv>=1.0.1",
   "requests>=2.25.0",
   "fastapi>=0.100.0", # For OpenAPI parsing utils if used later, and data validation

--- a/tests/unit/test_mcp_dependency_pin.py
+++ b/tests/unit/test_mcp_dependency_pin.py
@@ -1,0 +1,57 @@
+"""
+Regression test for the fresh-install crash caused by an unpinned mcp dependency.
+
+`mcp[cli]>=1.2.0` used to resolve to mcp 2.x on fresh installs, which broke both
+server modes at import time:
+- FastMCP mode: `mcp.server.fastmcp` was removed in 2.x (FastMCP -> MCPServer).
+- Low-level mode: `types.Resource.uri` changed from AnyUrl to str, so the
+  module-level Resource construction failed pydantic validation.
+
+These tests assert the installed mcp is a pinned 1.x and that both server modes
+actually import against it.
+"""
+
+import importlib
+import importlib.metadata
+
+from packaging.requirements import Requirement
+from packaging.version import Version
+
+
+def _installed_mcp_version() -> Version:
+    return Version(importlib.metadata.version("mcp"))
+
+
+def test_installed_mcp_is_1x():
+    """The environment must resolve mcp to the known-good 1.x line."""
+    version = _installed_mcp_version()
+    assert version.major == 1, (
+        f"mcp {version} is installed; mcp 2.x breaks both server modes "
+        "(see pin in pyproject.toml)"
+    )
+
+
+def test_pyproject_pins_mcp_below_2():
+    """The declared dependency must exclude mcp 2.x so fresh installs stay on 1.x."""
+    requires = importlib.metadata.requires("mcp-openapi-proxy") or []
+    mcp_reqs = [
+        Requirement(r) for r in requires if Requirement(r).name.lower() == "mcp"
+    ]
+    assert mcp_reqs, "mcp-openapi-proxy must declare a dependency on mcp"
+    for req in mcp_reqs:
+        assert not req.specifier.contains("2.0.0", prereleases=True), (
+            f"dependency '{req}' permits mcp 2.x, which crashes both server modes; "
+            "pin it below 2 (e.g. 'mcp[cli]>=1.2.0,<2')"
+        )
+
+
+def test_lowlevel_server_imports():
+    """Low-level mode must import cleanly against the pinned mcp."""
+    module = importlib.import_module("mcp_openapi_proxy.server_lowlevel")
+    assert hasattr(module, "run_server")
+
+
+def test_fastmcp_server_imports():
+    """FastMCP (simple) mode must import cleanly against the pinned mcp."""
+    module = importlib.import_module("mcp_openapi_proxy.server_fastmcp")
+    assert hasattr(module, "run_simple_server")

--- a/uv.lock
+++ b/uv.lock
@@ -407,7 +407,7 @@ cli = [
 
 [[package]]
 name = "mcp-openapi-proxy"
-version = "0.2.1"
+version = "0.3.4"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
@@ -431,7 +431,7 @@ dev = [
 requires-dist = [
     { name = "fastapi", specifier = ">=0.100.0" },
     { name = "jmespath", specifier = ">=1.0.1" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.2.0" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.2.0,<2" },
     { name = "openapi-spec-validator", specifier = ">=0.7.1" },
     { name = "prance", specifier = ">=23.6.21.0" },
     { name = "pydantic", specifier = ">=2.0" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

A fresh `pip install mcp-openapi-proxy` crashes on startup in **both** server modes. The dependency `mcp[cli]>=1.2.0` is unpinned, and mcp 2.x is now on PyPI (latest 2.1.1), so fresh installs resolve to 2.x — a breaking rewrite:

- **FastMCP (simple) mode**: `from mcp.server.fastmcp import FastMCP` raises `ModuleNotFoundError` — the module was removed in 2.x (FastMCP was renamed to `MCPServer`).
- **Low-level mode**: `types.Resource.uri` changed from `AnyUrl` to `str`, so the module-level `Resource(...)` construction in `server_lowlevel.py` fails pydantic validation at import time.

Both crashes were reproduced in a clean venv against mcp 2.1.1. Dev environments were unaffected because `uv.lock` pins mcp 1.2.1 — only fresh installs hit this.

## Fix

- Pin the dependency to the known-good 1.x line: `mcp[cli]>=1.2.0,<2`. Verified both server modes import successfully at both ends of the range: 1.2.1 (locked) and 1.29.1 (what a fresh install now resolves to).
- Updated `uv.lock` minimally: the project's `requires-dist` specifier and its version (which was stale at 0.2.1). Validated with `uv lock --check`; no resolved dependency versions changed.
- Bumped version 0.3.3 → 0.3.4 and added a CHANGELOG entry (the unreleased render-example fix from #59 ships with it).

## Regression test

`tests/unit/test_mcp_dependency_pin.py` (4 tests, all passing):
- installed mcp is 1.x
- the declared dependency specifier excludes 2.0.0 (catches accidental un-pinning)
- `mcp_openapi_proxy.server_lowlevel` imports successfully
- `mcp_openapi_proxy.server_fastmcp` imports successfully

## Test results

Full unit suite: 146 passed, 3 failed — the 3 failures (`test_fastmcp_list_prompts`, `test_fastmcp_list_resources`, `test_fastmcp_uri_substitution`) fail identically on `main` and are unrelated to this change.

No source code changes; no secrets or `.env` touched.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-30bb7675-7c6a-4565-b0b8-c0d1a59f984a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-30bb7675-7c6a-4565-b0b8-c0d1a59f984a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

