### PR TITLE
fix(deps): pin mcp to 1.x — mcp 2.x breaks both server modes (0.3.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,17 @@
 # Changelog
 
-## Unreleased
+## 0.3.4
 
 ### Fixed
+- **Pin `mcp` to 1.x** (`mcp[cli]>=1.2.0,<2`). The previous unbounded
+  `mcp>=1.2.0` constraint let a fresh `pip install mcp-openapi-proxy` resolve
+  to the mcp 2.x SDK, a breaking rewrite that crashed **both server modes at
+  import time**: FastMCP mode with `ModuleNotFoundError: No module named
+  'mcp.server.fastmcp'` (renamed to `MCPServer` in 2.x), and low-level mode
+  with a pydantic `ValidationError` constructing `types.Resource`
+  (`uri` field type change). Regression tests added
+  (`tests/unit/test_mcp_version_pin.py`) that fail closed on mcp 2.x and
+  guard the declared constraint so 2.x cannot be silently selected again.
 - `render` example: point `sample_mcpServers.json` at Render's live OpenAPI spec
   (`https://api-docs.render.com/openapi/render-public-api-1.json`). The previous
   id-based URL 302-redirects to `/404`, so the example registered **zero tools**.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,14 +5,17 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "mcp-openapi-proxy"
 requires-python = ">=3.10"
-version = "0.3.3"
+version = "0.3.4"
 description = "MCP server for exposing OpenAPI specifications as MCP tools."
 readme = "README.md"
 authors = [
   { name = "Matthew Hand", email = "11550632+matthewhand@users.noreply.github.com" }
 ]
 dependencies = [
-  "mcp[cli]>=1.2.0",
+  # mcp 2.x is a breaking rewrite (FastMCP renamed to MCPServer, Resource.uri type
+  # change, etc.) that crashes both server modes at import. Pin to 1.x; see
+  # tests/unit/test_mcp_version_pin.py before relaxing this bound.
+  "mcp[cli]>=1.2.0,<2",
   "python-dotenv>=1.0.1",
   "requests>=2.25.0",
   "fastapi>=0.100.0", # For OpenAPI parsing utils if used later, and data validation

--- a/tests/unit/test_mcp_version_pin.py
+++ b/tests/unit/test_mcp_version_pin.py
@@ -1,0 +1,119 @@
+"""
+Regression tests for the mcp dependency pin (issue: unpinned mcp>=1.2.0).
+
+mcp 2.x is a breaking rewrite of the Python SDK: `mcp.server.fastmcp` was
+renamed to `mcp.server.mcpserver.MCPServer`, and `types.Resource.uri` changed
+type, among other changes. With the old unbounded `mcp[cli]>=1.2.0` constraint
+a fresh `pip install mcp-openapi-proxy` resolved to mcp 2.x and both server
+modes crashed at import time:
+
+- server_fastmcp:  ModuleNotFoundError: No module named 'mcp.server.fastmcp'
+- server_lowlevel: pydantic ValidationError constructing types.Resource
+                   (uri: "Input should be a valid string", got AnyUrl)
+
+These tests fail closed if mcp 2.x is ever installed alongside this package,
+and guard the declared constraint so 2.x cannot be silently selected again.
+"""
+
+import re
+from importlib import metadata
+from pathlib import Path
+
+import pytest
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
+
+PYPROJECT = Path(__file__).resolve().parents[2] / "pyproject.toml"
+
+
+def _declared_mcp_specifier() -> SpecifierSet:
+    """Extract the mcp version specifier declared in pyproject.toml.
+
+    Parsed from the source tree (not installed metadata) so the guard also
+    runs correctly when tests execute without the package installed.
+    """
+    text = PYPROJECT.read_text(encoding="utf-8")
+    match = re.search(r'"mcp(?:\[[^\]]*\])?\s*([><=!~][^"]+)"', text)
+    assert match, "mcp dependency with version specifier not found in pyproject.toml"
+    return SpecifierSet(match.group(1))
+
+
+def test_declared_constraint_excludes_mcp_2x():
+    """The pyproject constraint must not allow any mcp 2.x release."""
+    spec = _declared_mcp_specifier()
+    for two_x in ("2.0.0", "2.0.1", "2.1.1", "2.99.0"):
+        assert not spec.contains(two_x), (
+            f"pyproject.toml mcp constraint {spec!r} permits mcp {two_x}; "
+            "mcp 2.x breaks both server modes at import (FastMCP renamed, "
+            "Resource.uri type change). Keep the <2 upper bound."
+        )
+
+
+def test_declared_constraint_accepts_supported_1x():
+    """The constraint must still resolve to the 1.x line this package uses."""
+    spec = _declared_mcp_specifier()
+    for one_x in ("1.2.0", "1.2.1", "1.29.1"):
+        assert spec.contains(one_x), (
+            f"pyproject.toml mcp constraint {spec!r} rejects mcp {one_x}"
+        )
+
+
+def test_installed_mcp_is_1x():
+    """Fail closed if the environment somehow has mcp 2.x installed."""
+    installed = Version(metadata.version("mcp"))
+    assert installed.major == 1, (
+        f"Installed mcp is {installed}, but mcp-openapi-proxy only supports "
+        "mcp 1.x (2.x renamed mcp.server.fastmcp and changed types.Resource)."
+    )
+    declared = _declared_mcp_specifier()
+    assert declared.contains(str(installed)), (
+        f"Installed mcp {installed} violates declared constraint {declared!r}"
+    )
+
+
+def test_mcp_1x_server_api_surface_present():
+    """Import the exact mcp SDK symbols both server modes depend on.
+
+    Every one of these disappears or breaks on mcp 2.x, so this test crashes
+    there instead of letting the proxy fail later at runtime.
+    """
+    from mcp import types  # noqa: F401
+    from mcp.server.fastmcp import FastMCP  # noqa: F401  (gone in 2.x)
+    from mcp.server.lowlevel import Server  # noqa: F401
+    from mcp.server.models import InitializationOptions  # noqa: F401
+    from mcp.server.stdio import stdio_server  # noqa: F401
+
+    # server_lowlevel builds this Resource at import time; on mcp 2.x the
+    # uri field type changed and this raises pydantic.ValidationError.
+    from pydantic import AnyUrl
+
+    resource = types.Resource(
+        uri=AnyUrl("file:///openapi_spec.json"),
+        name="OpenAPI Specification",
+        mimeType="application/json",
+    )
+    assert str(resource.uri) == "file:///openapi_spec.json"
+
+
+def test_both_server_modes_import():
+    """The original failure: both server modules crashed at import on mcp 2.x."""
+    import importlib
+
+    for mod in (
+        "mcp_openapi_proxy.server_lowlevel",
+        "mcp_openapi_proxy.server_fastmcp",
+    ):
+        importlib.import_module(mod)
+
+
+def test_uv_lock_pins_mcp_1x():
+    """uv.lock must lock mcp to a 1.x version consistent with pyproject."""
+    lock_path = PYPROJECT.parent / "uv.lock"
+    if not lock_path.exists():
+        pytest.skip("uv.lock not present")
+    text = lock_path.read_text(encoding="utf-8")
+    match = re.search(r'name = "mcp"\nversion = "([^"]+)"', text)
+    assert match, "mcp entry not found in uv.lock"
+    locked = Version(match.group(1))
+    assert locked.major == 1, f"uv.lock resolves mcp to {locked}, expected 1.x"
+    assert _declared_mcp_specifier().contains(str(locked))

--- a/uv.lock
+++ b/uv.lock
@@ -407,7 +407,7 @@ cli = [
 
 [[package]]
 name = "mcp-openapi-proxy"
-version = "0.2.1"
+version = "0.3.4"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
@@ -431,7 +431,7 @@ dev = [
 requires-dist = [
     { name = "fastapi", specifier = ">=0.100.0" },
     { name = "jmespath", specifier = ">=1.0.1" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.2.0" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.2.0,<2" },
     { name = "openapi-spec-validator", specifier = ">=0.7.1" },
     { name = "prance", specifier = ">=23.6.21.0" },
     { name = "pydantic", specifier = ">=2.0" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

A fresh `pip install mcp-openapi-proxy` is broken. The dependency constraint `mcp[cli]>=1.2.0` is unbounded, and PyPI now serves mcp 2.x (latest 2.1.1), a breaking rewrite of the Python SDK. Verified against mcp 2.1.1, **both server modes crash at import time**:

- **FastMCP / simple mode**: `ModuleNotFoundError: No module named 'mcp.server.fastmcp'` — the module was renamed to `mcp.server.mcpserver.MCPServer` in 2.x.
- **Low-level mode**: `pydantic.ValidationError` constructing `types.Resource` at module import — `Resource.uri` no longer accepts `AnyUrl` ("Input should be a valid string").

## Fix

- Pin the dependency to `mcp[cli]>=1.2.0,<2` in `pyproject.toml` (with a comment explaining why, pointing at the regression tests).
- Sync `uv.lock` minimally: the requires-dist specifier and the package's own version, which was stale at 0.2.1 in the lock. mcp stays locked at 1.2.1; no other resolution changes. Validated with `uv lock --check`.
- Bump version to **0.3.4** and add a changelog entry.

## Regression tests (`tests/unit/test_mcp_version_pin.py`)

- Declared constraint rejects 2.0.0 / 2.0.1 / 2.1.1 / 2.99.0 and still accepts 1.2.0 / 1.2.1 / 1.29.1.
- Installed `mcp` must be 1.x and satisfy the declared constraint (fails closed if 2.x sneaks in).
- The exact v1 SDK surface both server modes need imports cleanly (`mcp.server.fastmcp.FastMCP`, `mcp.server.lowlevel.Server`, `InitializationOptions`, `stdio_server`), plus the `types.Resource(uri=AnyUrl(...))` construction that 2.x rejects.
- Both `server_lowlevel` and `server_fastmcp` import successfully (the original crash).
- `uv.lock` resolves mcp to a 1.x consistent with pyproject.

## Verification

- Fresh resolution with the new pin selects **mcp 1.29.1** (latest 1.x), not 2.x.
- Unit suite passes identically on mcp **1.2.1** (locked) and **1.29.1** (fresh resolve): 144 passed each.
- In an mcp 2.1.1 environment, the suite fails loudly at collection with the mcp-2 `ModuleNotFoundError` — 2.x cannot be silently selected.
- Sanity-checked the new tests fail closed on mcp 2.1.1.

## Pre-existing failures (not touched, per no-drive-by scope)

`test_fastmcp_list_prompts`, `test_fastmcp_list_resources`, and `test_fastmcp_uri_substitution` fail identically on mcp 1.2.1 and 1.29.1, before and after this change: they set `OPENAPI_SPEC_URL=http://dummy.com` and perform a live fetch, and that parked domain now returns an HTML lander page instead of JSON. Environment/network issue, unrelated to the pin.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-906574e8-472e-46fe-8d77-f09f9d649023?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-906574e8-472e-46fe-8d77-f09f9d649023&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

