### PR TITLE
feat: GET /healthz on native Streamable HTTP (Fixes #66)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@
   `OpenApiProxy-LowLevel` on every instance.
 - Tests for handshake-free list/call, duplicate request ids, mixed-version
   clients, and multi-instance round-robin without sticky routing.
+- `GET /healthz` on native Streamable HTTP (`MCP_TRANSPORT=streamable-http`):
+  process-local `{"ok":true,"name":…,"port":…}` with no spec fetch, no
+  `initialize`, and no MCP request lock (so nested curls of the same
+  instance do not deadlock the single worker). Stdio and the 0.3.4 /
+  supergateway path are unchanged.
 
 ### Breaking
 - Requires `mcp` 2.x. `uvx mcp-openapi-proxy` without a `<2` pin now

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Refer to the **Examples** section below for practical configurations tailored to
 - `MCP_SERVER_NAME`: (Optional) Identity advertised in `serverInfo` / `server/discover`. Set this to the proxied API (e.g. `gpt-terminal-plus`, `flyio`) so multiple instances are not all called `openapi-proxy`. Falls back to the OpenAPI file stem or spec-URL host, then `openapi-proxy`.
 - `MCP_SERVER_TITLE` / `MCP_SERVER_DESCRIPTION`: (Optional) Display title and description alongside the name.
 - `MCP_TRANSPORT`: (Optional) `stdio` (default) or `streamable-http` for native stateless Streamable HTTP (MCP 2026-07-28; no `Mcp-Session-Id`).
-- `MCP_HOST` / `MCP_PORT` / `MCP_PATH`: (Optional) HTTP bind address (`127.0.0.1`), port (`8000`), and path (`/mcp`) when `MCP_TRANSPORT=streamable-http`.
+- `MCP_HOST` / `MCP_PORT` / `MCP_PATH`: (Optional) HTTP bind address (`127.0.0.1`), port (`8000`), and path (`/mcp`) when `MCP_TRANSPORT=streamable-http`. Native Streamable HTTP also serves `GET /healthz` → `{"ok":true,"name":<MCP_SERVER_NAME or fallback>,"port":<MCP_PORT>}` without taking the MCP request lock (no spec fetch, no `initialize`).
 - `MCP_JSON_RESPONSE`: (Optional) `true` (default) returns JSON instead of SSE on Streamable HTTP.
 - `MCP_LIST_TTL_MS` / `MCP_READ_TTL_MS`: (Optional) `ttlMs` for list results (default `60000`) and `resources/read` (default `5000`).
 - `MCP_ALLOWED_HOSTS`: (Optional) Comma-separated Host allow-list for DNS-rebinding protection. Default `*` (protection off — typical behind nginx).

--- a/docs/MIGRATION-0.4.md
+++ b/docs/MIGRATION-0.4.md
@@ -52,6 +52,7 @@ for 2026-era clients.
 | `MCP_HOST` | `127.0.0.1` | HTTP bind address |
 | `MCP_PORT` | `8000` | HTTP bind port |
 | `MCP_PATH` | `/mcp` | Streamable HTTP path |
+| `GET /healthz` | — | Process-local health JSON on native Streamable HTTP only (`{"ok":true,"name","port"}`). Does not take the MCP request lock. |
 | `MCP_JSON_RESPONSE` | `true` | JSON responses instead of SSE |
 | `MCP_LIST_TTL_MS` | `60000` | `ttlMs` for list results |
 | `MCP_READ_TTL_MS` | `5000` | `ttlMs` for `resources/read` |
@@ -131,3 +132,4 @@ legacy HTTP clients, and a 0.4.0 native listener for 2026-era clients.
 | retries / duplicate ids | `tests/unit/test_mcp2_protocol.py::test_http_duplicate_request_ids_are_independent` |
 | mixed-version (legacy initialize) | `tests/unit/test_mcp2_protocol.py::test_legacy_initialize_still_works` |
 | round-robin, two processes | `tests/integration/test_mcp2_http_roundrobin.py` |
+| GET /healthz body, no spec/lock | `tests/unit/test_healthz.py` |

--- a/mcp_openapi_proxy/protocol.py
+++ b/mcp_openapi_proxy/protocol.py
@@ -119,6 +119,32 @@ def mcp_path() -> str:
     return path
 
 
+HEALTHZ_PATH = "/healthz"
+
+
+def healthz_body() -> dict:
+    """Process-local health payload. Env only — no spec fetch, no MCP I/O."""
+    return {
+        "ok": True,
+        "name": advertised_server_name(),
+        "port": mcp_port(),
+    }
+
+
+async def healthz_endpoint(request: Any):
+    """Starlette handler for GET /healthz. Does not enter the MCP request lock."""
+    from starlette.responses import JSONResponse
+
+    return JSONResponse(healthz_body())
+
+
+def healthz_route():
+    """Sibling Starlette Route — not mounted under StreamableHTTPSessionManager."""
+    from starlette.routing import Route
+
+    return Route(HEALTHZ_PATH, endpoint=healthz_endpoint, methods=["GET"])
+
+
 def list_ttl_ms() -> int:
     return env_int("MCP_LIST_TTL_MS", DEFAULT_LIST_TTL_MS)
 

--- a/mcp_openapi_proxy/server_fastmcp.py
+++ b/mcp_openapi_proxy/server_fastmcp.py
@@ -20,11 +20,13 @@ from mcp_openapi_proxy.logging_setup import logger
 from mcp_openapi_proxy.openapi import fetch_openapi_spec, build_base_url, handle_auth
 from mcp_openapi_proxy.utils import is_tool_whitelisted, normalize_tool_name, strip_parameters, get_additional_headers, deduplicate_tool_name
 from mcp_openapi_proxy.protocol import (
+    HEALTHZ_PATH,
     PACKAGE_VERSION,
     advertised_server_description,
     advertised_server_name,
     advertised_server_title,
     cache_hints,
+    healthz_endpoint,
     json_response,
     mcp_host,
     mcp_path,
@@ -48,6 +50,8 @@ mcp = MCPServer(
     cache_hints=cache_hints(),
     request_state_security=request_state_security(),
 )
+# Sibling Starlette route: process-local /healthz, no MCP lock (issue #66).
+mcp.custom_route(HEALTHZ_PATH, methods=["GET"])(healthz_endpoint)
 
 spec = None  # Global spec for resources
 

--- a/mcp_openapi_proxy/server_lowlevel.py
+++ b/mcp_openapi_proxy/server_lowlevel.py
@@ -36,6 +36,7 @@ from mcp_openapi_proxy.protocol import (
     advertised_server_name,
     advertised_server_title,
     cache_hints,
+    healthz_route,
     json_response,
     mcp_host,
     mcp_path,
@@ -547,6 +548,22 @@ async def start_server():
     prewarm.cancel()
 
 
+def build_streamable_http_app(*, host: Optional[str] = None, path: Optional[str] = None):
+    """Starlette app for native Streamable HTTP plus process-local GET /healthz.
+
+    /healthz is a sibling custom_starlette_route so it never enters
+    StreamableHTTPSessionManager or the MCP request lock.
+    """
+    return mcp.streamable_http_app(
+        streamable_http_path=path or mcp_path(),
+        json_response=json_response(),
+        stateless_http=True,
+        transport_security=transport_security(),
+        host=host or mcp_host(),
+        custom_starlette_routes=[healthz_route()],
+    )
+
+
 def _run_streamable_http() -> None:
     """Stateless Streamable HTTP: no Mcp-Session-Id, no sticky routing."""
     import uvicorn
@@ -558,13 +575,7 @@ def _run_streamable_http() -> None:
         "Starting Low-Level MCP server (streamable-http, stateless) "
         f"on {host}:{port}{path}"
     )
-    app = mcp.streamable_http_app(
-        streamable_http_path=path,
-        json_response=json_response(),
-        stateless_http=True,
-        transport_security=transport_security(),
-        host=host,
-    )
+    app = build_streamable_http_app(host=host, path=path)
     uvicorn.run(app, host=host, port=port)
 
 

--- a/tests/unit/test_healthz.py
+++ b/tests/unit/test_healthz.py
@@ -1,0 +1,141 @@
+"""GET /healthz on native Streamable HTTP (issue #66).
+
+Process-local probe: 200 JSON {ok, name, port}. No OpenAPI spec fetch,
+no MCP initialize, no Mcp-Session-Id, no Streamable-HTTP request lock.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from mcp_openapi_proxy.protocol import (
+    HEADER_SESSION_ID,
+    healthz_body,
+    healthz_route,
+    modern_headers,
+    modern_request_meta,
+    transport_security,
+)
+
+TINY_SPEC = {
+    "openapi": "3.0.0",
+    "info": {"title": "healthz-test", "version": "1.0.0"},
+    "servers": [{"url": "http://example.test"}],
+    "paths": {
+        "/ping": {
+            "get": {
+                "summary": "Ping",
+                "operationId": "ping",
+                "responses": {"200": {"description": "ok"}},
+            }
+        }
+    },
+}
+
+
+def _reset_lowlevel():
+    import mcp_openapi_proxy.server_lowlevel as sl
+
+    sl.openapi_spec_data = None
+    sl._spec_load_error = None
+    sl._spec_load_lock = None
+    sl.tools.clear()
+
+
+@pytest.fixture
+def spec_env(tmp_path, monkeypatch):
+    spec_path = tmp_path / "spec.json"
+    spec_path.write_text(json.dumps(TINY_SPEC))
+    monkeypatch.setenv("OPENAPI_SPEC_URL", spec_path.as_uri())
+    monkeypatch.delenv("MCP_TRANSPORT", raising=False)
+    _reset_lowlevel()
+    yield spec_path
+    _reset_lowlevel()
+
+
+def test_healthz_body_uses_env_name_and_port(monkeypatch):
+    monkeypatch.setenv("MCP_SERVER_NAME", "gpt-terminal-plus")
+    monkeypatch.setenv("MCP_PORT", "8815")
+    assert healthz_body() == {"ok": True, "name": "gpt-terminal-plus", "port": 8815}
+
+
+def test_healthz_body_fallback_name_and_default_port(monkeypatch):
+    monkeypatch.delenv("MCP_SERVER_NAME", raising=False)
+    monkeypatch.delenv("OPENAPI_SERVER_NAME", raising=False)
+    monkeypatch.delenv("OPENAPI_SPEC_URL", raising=False)
+    monkeypatch.delenv("MCP_PORT", raising=False)
+    body = healthz_body()
+    assert body == {"ok": True, "name": "openapi-proxy", "port": 8000}
+
+
+def test_healthz_route_is_get_only_sibling():
+    route = healthz_route()
+    assert route.path == "/healthz"
+    assert route.methods == {"GET"}
+
+
+def test_http_healthz_200_body_shape(spec_env, monkeypatch):
+    from starlette.testclient import TestClient
+    import mcp_openapi_proxy.server_lowlevel as sl
+    import mcp_openapi_proxy.openapi as openapi
+    import mcp_openapi_proxy.utils as utils
+
+    def _boom(*_a, **_k):
+        raise AssertionError("healthz must not fetch the OpenAPI spec")
+
+    monkeypatch.setenv("MCP_SERVER_NAME", "gpt-terminal-plus")
+    monkeypatch.setenv("MCP_PORT", "8815")
+    monkeypatch.setattr(openapi, "fetch_openapi_spec", _boom)
+    monkeypatch.setattr(utils, "fetch_openapi_spec", _boom)
+    monkeypatch.setattr(sl, "fetch_openapi_spec", _boom)
+
+    sl.mcp = sl.build_server()
+    app = sl.build_streamable_http_app(host="testserver", path="/mcp")
+    with TestClient(app) as client:
+        resp = client.get("/healthz")
+        assert resp.status_code == 200, resp.text
+        assert resp.headers.get("content-type", "").startswith("application/json")
+        assert resp.json() == {"ok": True, "name": "gpt-terminal-plus", "port": 8815}
+        assert sl.openapi_spec_data is None
+        assert HEADER_SESSION_ID.lower() not in {k.lower() for k in resp.headers}
+
+
+def test_http_healthz_does_not_break_mcp_path(spec_env):
+    from starlette.testclient import TestClient
+    import mcp_openapi_proxy.server_lowlevel as sl
+
+    sl.mcp = sl.build_server()
+    app = sl.build_streamable_http_app(host="testserver", path="/mcp")
+    body = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/list",
+        "params": {"_meta": modern_request_meta()},
+    }
+    with TestClient(app) as client:
+        listed = client.post("/mcp", json=body, headers=modern_headers("tools/list"))
+        assert listed.status_code == 200, listed.text
+        healthy = client.get("/healthz")
+        assert healthy.status_code == 200
+        assert healthy.json()["ok"] is True
+
+
+def test_fastmcp_healthz_200_body_shape(monkeypatch):
+    from starlette.testclient import TestClient
+    from mcp_openapi_proxy import server_fastmcp as fm
+
+    monkeypatch.setenv("MCP_SERVER_NAME", "simple-mode")
+    monkeypatch.setenv("MCP_PORT", "9000")
+    app = fm.mcp.streamable_http_app(
+        streamable_http_path="/mcp",
+        json_response=True,
+        stateless_http=True,
+        transport_security=transport_security(),
+        host="testserver",
+    )
+    with TestClient(app) as client:
+        resp = client.get("/healthz")
+        assert resp.status_code == 200, resp.text
+        assert resp.json() == {"ok": True, "name": "simple-mode", "port": 9000}

--- a/tests/unit/test_healthz.py
+++ b/tests/unit/test_healthz.py
@@ -73,7 +73,9 @@ def test_healthz_body_fallback_name_and_default_port(monkeypatch):
 def test_healthz_route_is_get_only_sibling():
     route = healthz_route()
     assert route.path == "/healthz"
-    assert route.methods == {"GET"}
+    # Starlette adds HEAD alongside GET; MCP methods must not be on this route.
+    assert "GET" in (route.methods or set())
+    assert not (route.methods or set()) & {"POST", "DELETE"}
 
 
 def test_http_healthz_200_body_shape(spec_env, monkeypatch):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #66.

## Issue

**Intent:** Add a process-local health endpoint on native Streamable-HTTP (MCP 2026-07-28 / 0.4.0) so operators can probe instances like gpt-terminal-plus without taking the MCP request lock or nesting initialize/tools calls.

**Success:**
- GET /healthz returns 200 JSON `{"ok":true,"name":<MCP_SERVER_NAME or fallback>,"port":<MCP_PORT or configured>}`
- Handler does no OpenAPI spec fetch, no MCP initialize, and does not contend with Streamable-HTTP MCP request handling
- Works when MCP_TRANSPORT=streamable-http (default native path); does not break stdio or MCP_GATEWAY_HTTP=supergateway / 0.3.4 paths
- Minimal tests cover 200 body shape
- PR targets branch feat/mcp-2.x-2026-07-28 (0.4.0); link Fixes this Issue

**Constraints:** Do not revert SDK 2 / 0.4.0. Do not require Mcp-Session-Id or sticky sessions. No secrets in repo. Keep older 0.3.4 workflow intact (escape hatch / pin path).

**Owner:** MCP Bot coordinator + Cursor cloud agent

## Feasibility

Confirmed. `Server.streamable_http_app(..., custom_starlette_routes=)` (and FastMCP `@custom_route`) registers a sibling Starlette `Route` next to `/mcp`. That path is handled by Starlette routing and never enters `StreamableHTTPSessionManager` or the MCP request lock. Name/port come from existing `advertised_server_name()` / `mcp_port()` (env only). Stdio never builds the HTTP app.

## What changed

- `GET /healthz` on native Streamable HTTP (low-level and FastMCP/simple mode)
- Response: `{"ok": true, "name": <MCP_SERVER_NAME or advertised fallback>, "port": <MCP_PORT or 8000>}`
- No spec fetch, no `initialize`, no `Mcp-Session-Id`
- Stdio and 0.3.4 / supergateway paths untouched
- Tests in `tests/unit/test_healthz.py`

## Verification

`pytest tests/unit` — 167 passed. Healthz tests cover 200 body shape (`ok` / `name` / `port`), no OpenAPI spec fetch, no session header, and `POST /mcp` still works after the sibling route is registered.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-509ca3b9-a10f-48bd-ba5f-9af23c37724d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-509ca3b9-a10f-48bd-ba5f-9af23c37724d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

