### PR TITLE
Add MCP tool annotations to tools/list (Fixes #69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@
   (`mcp rpc method=tools/list` or `mcp rpc method=tools/call name=…`) so
   uvicorn `POST /mcp 200` can be attributed. Arguments, Authorization,
   tokens, and request bodies are not logged. Stdio is unchanged.
+- MCP `annotations` on every OpenAPI-derived `tools/list` entry (`title`,
+  `readOnlyHint` / `idempotentHint` for GET and clearly read-ish POST,
+  `destructiveHint` for other methods). Hints are derived from the HTTP
+  method (Notion pattern). `additionalProperties` and RPC logging are
+  unchanged.
 
 ### Breaking
 - Requires `mcp` 2.x. `uvx mcp-openapi-proxy` without a `<2` pin now

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ The package offers two operational modes:
 ## Features
 
 - **Dynamic Tool Generation:** Automatically creates MCP tools from OpenAPI endpoint definitions.
+- **Tool Annotations:** Every OpenAPI-derived tool includes MCP `annotations` (`title`, plus `readOnlyHint` / `idempotentHint` for GET and clearly read-ish POST, or `destructiveHint` for other methods) so clients such as Gemini Spark see the same fingerprint as Notion/Linear.
 - **Simple Mode Option:** Offers a static configuration alternative via FastMCP mode.
 - **OpenAPI Specification Support:** Compatible with OpenAPI v3 with potential support for v2.
 - **Flexible Filtering:** Allows endpoint filtering through whitelisting by paths or other criteria.

--- a/docs/MIGRATION-0.4.md
+++ b/docs/MIGRATION-0.4.md
@@ -39,6 +39,8 @@ Mcp-Name: get_ping
 - Gateways route on `MCP-Protocol-Version`, `Mcp-Method`, `Mcp-Name`.
 - Header/body mismatch is rejected (`-32020`).
 - `tools/list` (and other list/read results) include `ttlMs` and `cacheScope`.
+- Each OpenAPI-derived tool includes MCP `annotations` (`title` plus
+  method-derived `readOnlyHint` / `idempotentHint` or `destructiveHint`).
 
 Stdio remains dual-stack: the SDK still answers `initialize` so Codex / Gemini /
 Qwen keep working, and it also answers `server/discover` + per-request `_meta`

--- a/mcp_openapi_proxy/openapi.py
+++ b/mcp_openapi_proxy/openapi.py
@@ -37,7 +37,7 @@ def _identifier_tokens(text: str) -> List[str]:
         return []
     spaced = re.sub(r"(?<=[a-z0-9])([A-Z])", r" \1", text)
     spaced = spaced.replace("_", " ").replace("-", " ")
-    return [part.lower() for part in re.findall(r"[a-z0-9]+", spaced)]
+    return [part.lower() for part in re.findall(r"[A-Za-z0-9]+", spaced)]
 
 
 def human_tool_title(tool_name: str, operation: Optional[Dict] = None) -> str:

--- a/mcp_openapi_proxy/openapi.py
+++ b/mcp_openapi_proxy/openapi.py
@@ -7,7 +7,7 @@ import json
 import re # Import the re module
 import requests
 import yaml
-from typing import Dict, Optional, List, Union
+from typing import Dict, Optional, List, Union, Set
 from urllib.parse import unquote, quote
 from mcp import types
 from mcp_openapi_proxy.utils import normalize_tool_name
@@ -15,6 +15,114 @@ from .logging_setup import logger
 
 # Define the required tool name pattern
 TOOL_NAME_REGEX = r"^[a-zA-Z0-9_-]{1,64}$"
+
+# First-token / token sets used to treat a POST as read-ish (search/query/list).
+# Write tokens win so getOrCreate / searchAndCreate stay destructive.
+_READISH_TOKENS = frozenset({
+    "get", "list", "search", "query", "find", "fetch", "filter",
+    "lookup", "read", "count", "exists", "check", "status", "ping",
+    "health", "describe", "show", "view",
+})
+_WRITE_TOKENS = frozenset({
+    "create", "update", "delete", "post", "put", "patch", "add",
+    "remove", "set", "send", "write", "upsert",
+})
+_SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS", "TRACE"})
+_IDEMPOTENT_WRITE_METHODS = frozenset({"PUT", "DELETE"})
+
+
+def _identifier_tokens(text: str) -> List[str]:
+    """Split camelCase / snake_case / kebab-case into lowercase tokens."""
+    if not text:
+        return []
+    spaced = re.sub(r"(?<=[a-z0-9])([A-Z])", r" \1", text)
+    spaced = spaced.replace("_", " ").replace("-", " ")
+    return [part.lower() for part in re.findall(r"[a-z0-9]+", spaced)]
+
+
+def human_tool_title(tool_name: str, operation: Optional[Dict] = None) -> str:
+    """Human title for annotations.title: short summary, else operationId, else tool name."""
+    operation = operation or {}
+    summary = operation.get("summary")
+    if isinstance(summary, str):
+        summary = summary.strip()
+        if summary and len(summary) <= 80:
+            return summary
+    op_id = operation.get("operationId")
+    if isinstance(op_id, str) and op_id.strip():
+        return _humanize_identifier(op_id)
+    return _humanize_identifier(tool_name)
+
+
+def _humanize_identifier(name: str) -> str:
+    tokens = _identifier_tokens(name)
+    if not tokens:
+        return name
+    return " ".join(token[:1].upper() + token[1:] for token in tokens)
+
+
+def _is_readish_post(operation: Optional[Dict]) -> bool:
+    """True when a POST looks like search/query/list rather than a write."""
+    operation = operation or {}
+    texts = []
+    for key in ("operationId", "summary"):
+        val = operation.get(key)
+        if isinstance(val, str) and val.strip():
+            texts.append(val)
+    if not texts:
+        return False
+    tokens: Set[str] = set()
+    first_tokens: List[str] = []
+    for text in texts:
+        parts = _identifier_tokens(text)
+        tokens.update(parts)
+        if parts:
+            first_tokens.append(parts[0])
+    if tokens & _WRITE_TOKENS:
+        return False
+    return any(first in _READISH_TOKENS for first in first_tokens)
+
+
+def build_tool_annotations(
+    method: Optional[str],
+    tool_name: str,
+    operation: Optional[Dict] = None,
+    *,
+    read_only: Optional[bool] = None,
+) -> types.ToolAnnotations:
+    """MCP ToolAnnotations derived from the OpenAPI HTTP method (Notion pattern).
+
+    GET/HEAD/OPTIONS (and clearly read-ish POST) set readOnlyHint + idempotentHint.
+    Other methods set destructiveHint; PUT/DELETE also set idempotentHint.
+    """
+    title = human_tool_title(tool_name, operation)
+    method_upper = (method or "").upper()
+    if read_only is True or method_upper in _SAFE_METHODS or (
+        method_upper == "POST" and _is_readish_post(operation)
+    ):
+        return types.ToolAnnotations(
+            title=title,
+            read_only_hint=True,
+            idempotent_hint=True,
+        )
+    return types.ToolAnnotations(
+        title=title,
+        destructive_hint=True,
+        idempotent_hint=True if method_upper in _IDEMPOTENT_WRITE_METHODS else None,
+    )
+
+
+def annotations_wire_dict(
+    method: Optional[str],
+    tool_name: str,
+    operation: Optional[Dict] = None,
+    *,
+    read_only: Optional[bool] = None,
+) -> Dict:
+    """CamelCase annotations object for JSON tools/list (and simple-mode catalogs)."""
+    return build_tool_annotations(
+        method, tool_name, operation, read_only=read_only
+    ).model_dump(by_alias=True, exclude_none=True)
 
 def fetch_openapi_spec(url: str, retries: int = 3) -> Optional[Dict]:
     """Fetch and parse an OpenAPI specification from a URL with retries."""
@@ -294,11 +402,16 @@ def register_functions(spec: Dict) -> List[types.Tool]:
                                #         input_schema['required'].append('body')
 
 
-                # Create and register the tool
+                # Create and register the tool. Annotations follow MCP ToolAnnotations
+                # (title + method-derived hints) so clients such as Gemini Spark see
+                # the same fingerprint as Notion/Linear.
+                annotations = build_tool_annotations(method, function_name, operation)
                 tool = types.Tool(
                     name=function_name,
+                    title=annotations.title,
                     description=description,
                     inputSchema=input_schema,
+                    annotations=annotations,
                 )
                 tools_list.append(tool)
                 registered_names.add(function_name)

--- a/mcp_openapi_proxy/server_fastmcp.py
+++ b/mcp_openapi_proxy/server_fastmcp.py
@@ -17,7 +17,13 @@ import requests
 from typing import Dict, Any, Optional
 from mcp.server.mcpserver import MCPServer
 from mcp_openapi_proxy.logging_setup import logger
-from mcp_openapi_proxy.openapi import fetch_openapi_spec, build_base_url, handle_auth
+from mcp import types as mcp_types
+from mcp_openapi_proxy.openapi import (
+    annotations_wire_dict,
+    fetch_openapi_spec,
+    build_base_url,
+    handle_auth,
+)
 from mcp_openapi_proxy.utils import is_tool_whitelisted, normalize_tool_name, strip_parameters, get_additional_headers, deduplicate_tool_name
 from mcp_openapi_proxy.protocol import (
     HEALTHZ_PATH,
@@ -109,7 +115,14 @@ def _whimsical_blog_prompt() -> str:
             "✨ Write the next whimsical chapter.")
 
 
-@mcp.tool()
+@mcp.tool(
+    title="List Functions",
+    annotations=mcp_types.ToolAnnotations(
+        title="List Functions",
+        read_only_hint=True,
+        idempotent_hint=True,
+    ),
+)
 def list_functions(*, env_key: str = "OPENAPI_SPEC_URL") -> str:
     """Lists available functions derived from the OpenAPI specification."""
     logger.debug("Executing list_functions tool.")
@@ -224,7 +237,8 @@ def list_functions(*, env_key: str = "OPENAPI_SPEC_URL") -> str:
                 "method": method.upper(),
                 "operationId": operation.get("operationId"),
                 "original_name": raw_name,
-                "inputSchema": input_schema
+                "inputSchema": input_schema,
+                "annotations": annotations_wire_dict(method, function_name, operation),
             }
             _FUNCTION_OPERATIONS[function_name] = {
                 "path": path,
@@ -239,7 +253,8 @@ def list_functions(*, env_key: str = "OPENAPI_SPEC_URL") -> str:
         "method": None,
         "operationId": None,
         "original_name": "list_resources",
-        "inputSchema": {"type": "object", "properties": {}, "required": [], "additionalProperties": False}
+        "inputSchema": {"type": "object", "properties": {}, "required": [], "additionalProperties": False},
+        "annotations": annotations_wire_dict(None, "list_resources", read_only=True),
     }
     functions["read_resource"] = {
         "name": "read_resource",
@@ -249,7 +264,8 @@ def list_functions(*, env_key: str = "OPENAPI_SPEC_URL") -> str:
         "method": None,
         "operationId": None,
         "original_name": "read_resource",
-        "inputSchema": {"type": "object", "properties": {"uri": {"type": "string", "description": "Resource URI"}}, "required": ["uri"], "additionalProperties": False}
+        "inputSchema": {"type": "object", "properties": {"uri": {"type": "string", "description": "Resource URI"}}, "required": ["uri"], "additionalProperties": False},
+        "annotations": annotations_wire_dict(None, "read_resource", read_only=True),
     }
     functions["list_prompts"] = {
         "name": "list_prompts",
@@ -259,7 +275,8 @@ def list_functions(*, env_key: str = "OPENAPI_SPEC_URL") -> str:
         "method": None,
         "operationId": None,
         "original_name": "list_prompts",
-        "inputSchema": {"type": "object", "properties": {}, "required": [], "additionalProperties": False}
+        "inputSchema": {"type": "object", "properties": {}, "required": [], "additionalProperties": False},
+        "annotations": annotations_wire_dict(None, "list_prompts", read_only=True),
     }
     functions["get_prompt"] = {
         "name": "get_prompt",
@@ -269,7 +286,8 @@ def list_functions(*, env_key: str = "OPENAPI_SPEC_URL") -> str:
         "method": None,
         "operationId": None,
         "original_name": "get_prompt",
-        "inputSchema": {"type": "object", "properties": {"name": {"type": "string", "description": "Prompt name"}}, "required": ["name"], "additionalProperties": False}
+        "inputSchema": {"type": "object", "properties": {"name": {"type": "string", "description": "Prompt name"}}, "required": ["name"], "additionalProperties": False},
+        "annotations": annotations_wire_dict(None, "get_prompt", read_only=True),
     }
     logger.debug(f"Discovered {len(functions)} functions from the OpenAPI specification.")
     if "get_tasks_id" not in functions:
@@ -291,13 +309,24 @@ def list_functions(*, env_key: str = "OPENAPI_SPEC_URL") -> str:
                 },
                 "required": ["user_id"],
                 "additionalProperties": False
-            }
+            },
+            "annotations": annotations_wire_dict(
+                "GET",
+                "get_tasks_id",
+                {"summary": "Get tasks", "operationId": "get_users_tasks"},
+            ),
         }
         logger.debug("Forced registration of get_tasks_id for testing.")
     logger.debug(f"Functions list: {list(functions.values())}")
     return json.dumps(list(functions.values()), indent=2)
 
-@mcp.tool()
+@mcp.tool(
+    title="Call Function",
+    annotations=mcp_types.ToolAnnotations(
+        title="Call Function",
+        destructive_hint=True,
+    ),
+)
 def call_function(*, function_name: str = "", parameters: Optional[Dict] = None, env_key: str = "OPENAPI_SPEC_URL", handle: str = "") -> str:
     """Calls a function derived from the OpenAPI specification.
 

--- a/tests/unit/test_mcp2_protocol.py
+++ b/tests/unit/test_mcp2_protocol.py
@@ -165,6 +165,16 @@ def test_http_tools_list_no_session_header(spec_env):
         assert "tools" in result
         assert "ttlMs" in result
         assert result["ttlMs"] >= 0
+        # Issue #69: every tool carries MCP annotations (readOnlyHint on GET /ping).
+        assert result["tools"]
+        for tool in result["tools"]:
+            annotations = tool.get("annotations")
+            assert isinstance(annotations, dict), f"{tool.get('name')} missing annotations"
+        assert any(
+            (t.get("annotations") or {}).get("readOnlyHint") is True
+            or (t.get("annotations") or {}).get("destructiveHint") is True
+            for t in result["tools"]
+        )
 
 
 def test_http_tools_call_no_prior_handshake(spec_env, monkeypatch):

--- a/tests/unit/test_tool_annotations.py
+++ b/tests/unit/test_tool_annotations.py
@@ -1,0 +1,239 @@
+"""MCP ToolAnnotations on OpenAPI-derived tools (issue #69).
+
+Every tools/list entry must carry an annotations object. GET (and clearly
+read-ish POST) set readOnlyHint; other methods set destructiveHint. Titles
+are humanized from the operation/tool name. additionalProperties stays False.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from mcp_openapi_proxy.openapi import (
+    annotations_wire_dict,
+    build_tool_annotations,
+    human_tool_title,
+    register_functions,
+)
+
+MIXED_SPEC = {
+    "openapi": "3.0.0",
+    "info": {"title": "annotations-test", "version": "1.0.0"},
+    "servers": [{"url": "http://example.test"}],
+    "paths": {
+        "/users": {
+            "get": {
+                "summary": "List users",
+                "operationId": "listUsers",
+                "responses": {"200": {"description": "ok"}},
+            },
+            "post": {
+                "summary": "Create user",
+                "operationId": "createUser",
+                "responses": {"201": {"description": "created"}},
+            },
+        },
+        "/users/{id}": {
+            "put": {
+                "summary": "Replace user",
+                "operationId": "replaceUser",
+                "parameters": [
+                    {"name": "id", "in": "path", "required": True, "schema": {"type": "string"}}
+                ],
+                "responses": {"200": {"description": "ok"}},
+            },
+            "delete": {
+                "summary": "Delete user",
+                "operationId": "deleteUser",
+                "parameters": [
+                    {"name": "id", "in": "path", "required": True, "schema": {"type": "string"}}
+                ],
+                "responses": {"204": {"description": "gone"}},
+            },
+        },
+        "/search": {
+            "post": {
+                "summary": "Search users",
+                "operationId": "searchUsers",
+                "responses": {"200": {"description": "ok"}},
+            }
+        },
+    },
+}
+
+
+def test_human_title_prefers_short_summary():
+    assert human_tool_title("get_users", {"summary": "List users", "operationId": "listUsers"}) == "List users"
+
+
+def test_human_title_falls_back_to_operation_id():
+    assert human_tool_title("get_users", {"operationId": "listUsers"}) == "List Users"
+
+
+def test_human_title_falls_back_to_tool_name():
+    assert human_tool_title("get_users_by_id", {}) == "Get Users By Id"
+
+
+def test_get_annotations_are_read_only():
+    ann = build_tool_annotations("GET", "get_users", {"summary": "List users"})
+    assert ann.title == "List users"
+    assert ann.read_only_hint is True
+    assert ann.idempotent_hint is True
+    assert ann.destructive_hint is None
+
+
+def test_post_write_is_destructive():
+    ann = build_tool_annotations("POST", "post_users", {"summary": "Create user", "operationId": "createUser"})
+    assert ann.destructive_hint is True
+    assert ann.read_only_hint is None
+    assert ann.idempotent_hint is None
+
+
+def test_readish_post_is_read_only():
+    ann = build_tool_annotations("POST", "post_search", {"summary": "Search users", "operationId": "searchUsers"})
+    assert ann.read_only_hint is True
+    assert ann.idempotent_hint is True
+    assert ann.destructive_hint is None
+
+
+def test_get_or_create_post_stays_destructive():
+    ann = build_tool_annotations("POST", "post_users", {"operationId": "getOrCreateUser"})
+    assert ann.destructive_hint is True
+    assert ann.read_only_hint is None
+
+
+def test_put_and_delete_are_destructive_and_idempotent():
+    put = build_tool_annotations("PUT", "put_users_by_id", {"summary": "Replace user"})
+    delete = build_tool_annotations("DELETE", "delete_users_by_id", {"summary": "Delete user"})
+    assert put.destructive_hint is True
+    assert put.idempotent_hint is True
+    assert delete.destructive_hint is True
+    assert delete.idempotent_hint is True
+
+
+def test_wire_dict_uses_camel_case_and_drops_nulls():
+    dumped = annotations_wire_dict("GET", "get_ping", {"summary": "Ping"})
+    assert dumped == {
+        "title": "Ping",
+        "readOnlyHint": True,
+        "idempotentHint": True,
+    }
+    write = annotations_wire_dict("POST", "post_users", {"summary": "Create user"})
+    assert write["destructiveHint"] is True
+    assert "readOnlyHint" not in write
+
+
+def test_register_functions_attaches_annotations_to_every_tool():
+    tools = register_functions(MIXED_SPEC)
+    assert tools, "expected OpenAPI-derived tools"
+    hinted = False
+    for tool in tools:
+        assert tool.annotations is not None, f"{tool.name} missing annotations"
+        assert tool.annotations.title, f"{tool.name} missing annotations.title"
+        assert tool.input_schema.get("additionalProperties") is False
+        hinted = hinted or (
+            tool.annotations.read_only_hint is True or tool.annotations.destructive_hint is True
+        )
+    assert hinted, "at least one tool must set readOnlyHint or destructiveHint"
+
+    by_name = {t.name: t for t in tools}
+    assert by_name["get_users"].annotations.read_only_hint is True
+    assert by_name["post_users"].annotations.destructive_hint is True
+    assert by_name["post_search"].annotations.read_only_hint is True
+    assert by_name["put_users_by_id"].annotations.idempotent_hint is True
+    assert by_name["delete_users_by_id"].annotations.destructive_hint is True
+
+
+def test_list_tools_result_serializes_camel_case_annotations():
+    from mcp import types
+
+    tools = register_functions(MIXED_SPEC)
+    result = types.ListToolsResult(tools=tools)
+    payload = json.loads(result.model_dump_json(by_alias=True, exclude_none=True))
+    assert payload["tools"], "serialized tools/list had no tools"
+    hinted = False
+    for tool in payload["tools"]:
+        annotations = tool.get("annotations")
+        assert isinstance(annotations, dict), f"{tool.get('name')} missing annotations object"
+        assert annotations.get("title")
+        hinted = hinted or (
+            annotations.get("readOnlyHint") is True or annotations.get("destructiveHint") is True
+        )
+        # additionalProperties behavior is unchanged on the input schema
+        assert tool["inputSchema"].get("additionalProperties") is False
+    assert hinted
+
+
+def test_fastmcp_catalog_includes_annotations(monkeypatch):
+    from mcp_openapi_proxy import server_fastmcp as fm
+
+    monkeypatch.setattr(fm, "fetch_openapi_spec", lambda url: MIXED_SPEC)
+    monkeypatch.setenv("OPENAPI_SPEC_URL", "http://dummy_annotations")
+    listed = json.loads(fm.list_functions())
+    assert listed
+    hinted = False
+    for item in listed:
+        annotations = item.get("annotations")
+        assert isinstance(annotations, dict), f"{item.get('name')} missing annotations"
+        assert annotations.get("title")
+        hinted = hinted or (
+            annotations.get("readOnlyHint") is True or annotations.get("destructiveHint") is True
+        )
+        assert item["inputSchema"].get("additionalProperties") is False
+    assert hinted
+
+
+@pytest.mark.asyncio
+async def test_http_tools_list_includes_annotations(tmp_path, monkeypatch):
+    from starlette.testclient import TestClient
+
+    from mcp_openapi_proxy.protocol import modern_headers, modern_request_meta, transport_security
+    import mcp_openapi_proxy.server_lowlevel as sl
+
+    spec_path = tmp_path / "spec.json"
+    spec_path.write_text(json.dumps(MIXED_SPEC))
+    monkeypatch.setenv("OPENAPI_SPEC_URL", spec_path.as_uri())
+    sl.openapi_spec_data = None
+    sl._spec_load_error = None
+    sl._spec_load_lock = None
+    sl.tools.clear()
+    sl.mcp = sl.build_server()
+    app = sl.mcp.streamable_http_app(
+        streamable_http_path="/mcp",
+        json_response=True,
+        stateless_http=True,
+        transport_security=transport_security(),
+        host="testserver",
+    )
+    try:
+        with TestClient(app) as client:
+            resp = client.post(
+                "/mcp",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "tools/list",
+                    "params": {"_meta": modern_request_meta()},
+                },
+                headers=modern_headers("tools/list"),
+            )
+            assert resp.status_code == 200, resp.text
+            result = resp.json().get("result", resp.json())
+            tools = result["tools"]
+            assert tools
+            hinted = False
+            for tool in tools:
+                annotations = tool.get("annotations")
+                assert isinstance(annotations, dict), f"{tool.get('name')} missing annotations"
+                hinted = hinted or (
+                    annotations.get("readOnlyHint") is True
+                    or annotations.get("destructiveHint") is True
+                )
+            assert hinted, "tools/list must include readOnlyHint or destructiveHint on at least one tool"
+    finally:
+        sl.openapi_spec_data = None
+        sl._spec_load_error = None
+        sl._spec_load_lock = None
+        sl.tools.clear()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent
Add MCP tool annotations to `tools/list` so Gemini Spark (and similar clients) see the same annotation fingerprint as working servers (Notion/Linear), which may be required for client-side tool schema activation.

## Success
1. Every tool in `tools/list` for gpt-terminal-plus (and other OpenAPI-derived servers) includes an `annotations` object.
2. GET-derived tools set `readOnlyHint: true` (and `idempotentHint: true`); non-GET tools set `destructiveHint: true` unless clearly read-ish POST.
3. Include a human `title` derived from the operation/tool name (short OpenAPI summary, else humanized `operationId` / tool name).
4. Unit/integration tests assert at least one tool has `annotations.readOnlyHint` or `annotations.destructiveHint`, and that every listed tool carries `annotations`.
5. Live verify remains with MCP Bot on teamstinky: authenticated `tools/list` on gpt-terminal-plus should return annotations on all tools.

## Constraints
- Branched from `feat/mcp-2.x-2026-07-28` (mcp-openapi-proxy 0.4.0 / mcp>=2,<3).
- Does not change OAuth, transport, or protocolVersion negotiation.
- No secrets in the PR.
- Hints are derived from the OpenAPI HTTP method (Notion pattern). `additionalProperties: false` is unchanged.
- Streamable HTTP still logs `mcp rpc method=tools/call name=` with no args.

## Owner
MCP Bot / Matthew — cloud agent implements; MCP Bot deploys and verifies on teamstinky.

## What changed
- `register_functions` attaches `types.ToolAnnotations` (and `Tool.title`) to every OpenAPI-derived tool.
- GET/HEAD/OPTIONS (and POST whose `operationId`/`summary` first token is search/query/list/get/…) set `readOnlyHint` + `idempotentHint`.
- Other methods set `destructiveHint`; PUT/DELETE also set `idempotentHint`.
- FastMCP `list_functions` catalog and the `list_functions` / `call_function` MCP tools include the same fingerprint.
- Tests: `tests/unit/test_tool_annotations.py` plus a wire-format check on HTTP `tools/list`.

Fixes #69

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dfeba81e-e14d-4d21-b87d-58ab87a0fa74?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dfeba81e-e14d-4d21-b87d-58ab87a0fa74&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

