### PR TITLE
docs: dated 0.4.0 fanfare line at top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 **mcp-openapi-proxy** is a Python package that implements a Model Context Protocol (MCP) server, designed to dynamically expose REST APIs—defined by OpenAPI specifications—as MCP tools. This facilitates seamless integration of OpenAPI-described APIs into MCP-based workflows.
 
+**2026-09-05 — 0.4.0:** MCP 2.x / 2026-07-28 native Streamable HTTP (stateless POST /mcp, dual-stack with legacy stdio).
+
 ## What's New in 0.4.0
 
 **MCP 2026-07-28 (SDK 2.x).** The proxy is dual-stack: modern clients send


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent
Add a dated one-line fanfare under the README title for the 0.4.0 / MCP 2.x cutover (was missing vs 0.2.0 style).

## Success
1. Immediately under the H1 title (before What's New), a bold dated line e.g. **2026-09-05 — 0.4.0:** MCP 2.x / 2026-07-28 native Streamable HTTP (stateless POST /mcp, dual-stack with legacy stdio).
2. Keep existing What's New in 0.4.0 section; do not rewrite history.

## Constraints
- Branch from `feat/mcp-2.x-2026-07-28`. Docs-only. No code/secrets.

## Owner
MCP Bot / Matthew

## Change
One line after the title blurb, before What's New:

```markdown
**2026-09-05 — 0.4.0:** MCP 2.x / 2026-07-28 native Streamable HTTP (stateless POST /mcp, dual-stack with legacy stdio).
```

Date is the 0.4.0 MCP 2 cutover on this branch (`360ed13`, 2026-09-05). Existing What's New in 0.4.0 is unchanged.

Fixes #71

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-765bc66a-1322-4d52-961c-2f5448e80e5a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-765bc66a-1322-4d52-961c-2f5448e80e5a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

