### PR TITLE
feat: MCP 2026-07-28 / SDK 2.x (0.4.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,4 @@ cython_debug/
 
 *.bak
 *.swp
+readme.local.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## 0.4.0
+
+### Changed
+- **MCP Python SDK 2.x / protocol 2026-07-28.** The server is dual-stack:
+  2026-era clients send self-contained requests (no `initialize` handshake,
+  no `Mcp-Session-Id`); 2025-era clients may still `initialize` over stdio.
+  See [docs/MIGRATION-0.4.md](docs/MIGRATION-0.4.md).
+- Dependency: `mcp[cli]>=2.0.0,<3` (was `>=1.2.0,<2`). FastMCP is now
+  `MCPServer`; resource URIs are plain strings; handler fields are snake_case.
+- Streamable HTTP is a first-class transport (`MCP_TRANSPORT=streamable-http`)
+  and is **stateless**: every POST is self-contained, no sticky sessions.
+
+### Added
+- `ttlMs` / `cacheScope` on `tools/list`, `prompts/list`, `resources/list`,
+  `resources/read` (SEP-2549). Tune with `MCP_LIST_TTL_MS` / `MCP_READ_TTL_MS`.
+- `server/discover` (via the SDK) for version negotiation.
+- Explicit `handle` on simple-mode `list_functions` output; `call_function`
+  accepts `handle=` and rebuilds the operation map from the spec, so a
+  two-step flow works across instances.
+- `MCP_REQUEST_STATE_KEY` so MRTR `requestState` can be verified across
+  processes (shared HMAC). Unset keeps the SDK process-local default.
+- Tests for handshake-free list/call, duplicate request ids, mixed-version
+  clients, and multi-instance round-robin without sticky routing.
+
+### Breaking
+- Requires `mcp` 2.x. `uvx mcp-openapi-proxy` without a `<2` pin now
+  resolves correctly; 0.3.4 remains the last 1.x-SDK release.
+- Low-level handler registration is constructor `on_*` (SDK change). Gateway
+  wrappers that assigned `server.request_handlers[...]` must wrap
+  `dispatcher_handler` before `run_server()` (rebuilds the Server).
+- `types.Resource.uri` is `str`, not `AnyUrl`. Python attribute access is
+  snake_case (`input_schema`, `is_error`, `mime_type`); the JSON wire is
+  unchanged camelCase.
+
 ## 0.3.4
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@
   `initialize`, and no MCP request lock (so nested curls of the same
   instance do not deadlock the single worker). Stdio and the 0.3.4 /
   supergateway path are unchanged.
+- Native Streamable HTTP logs one INFO line per inbound JSON-RPC request
+  (`mcp rpc method=tools/list` or `mcp rpc method=tools/call name=…`) so
+  uvicorn `POST /mcp 200` can be attributed. Arguments, Authorization,
+  tokens, and request bodies are not logged. Stdio is unchanged.
 
 ### Breaking
 - Requires `mcp` 2.x. `uvx mcp-openapi-proxy` without a `<2` pin now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@
   `OpenApiProxy-LowLevel` on every instance.
 - Tests for handshake-free list/call, duplicate request ids, mixed-version
   clients, and multi-instance round-robin without sticky routing.
+- `GET /healthz` on native Streamable HTTP (`MCP_TRANSPORT=streamable-http`):
+  process-local `{"ok":true,"name":…,"port":…}` with no spec fetch, no
+  `initialize`, and no MCP request lock (so nested curls of the same
+  instance do not deadlock the single worker). Stdio and the 0.3.4 /
+  supergateway path are unchanged.
 
 ### Breaking
 - Requires `mcp` 2.x. `uvx mcp-openapi-proxy` without a `<2` pin now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
   two-step flow works across instances.
 - `MCP_REQUEST_STATE_KEY` so MRTR `requestState` can be verified across
   processes (shared HMAC). Unset keeps the SDK process-local default.
+- `MCP_SERVER_NAME` (plus optional `MCP_SERVER_TITLE` / `MCP_SERVER_DESCRIPTION`)
+  so `serverInfo` matches the proxied API instead of a generic
+  `OpenApiProxy-LowLevel` on every instance.
 - Tests for handshake-free list/call, duplicate request ids, mixed-version
   clients, and multi-instance round-robin without sticky routing.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@
   (`mcp rpc method=tools/list` or `mcp rpc method=tools/call name=…`) so
   uvicorn `POST /mcp 200` can be attributed. Arguments, Authorization,
   tokens, and request bodies are not logged. Stdio is unchanged.
+- MCP `annotations` on every OpenAPI-derived `tools/list` entry (`title`,
+  `readOnlyHint` / `idempotentHint` for GET and clearly read-ish POST,
+  `destructiveHint` for other methods). Hints are derived from the HTTP
+  method (Notion pattern). `additionalProperties` and RPC logging are
+  unchanged.
 
 ### Breaking
 - Requires `mcp` 2.x. `uvx mcp-openapi-proxy` without a `<2` pin now

--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 **mcp-openapi-proxy** is a Python package that implements a Model Context Protocol (MCP) server, designed to dynamically expose REST APIs—defined by OpenAPI specifications—as MCP tools. This facilitates seamless integration of OpenAPI-described APIs into MCP-based workflows.
 
+## What's New in 0.4.0
+
+**MCP 2026-07-28 (SDK 2.x).** The proxy is dual-stack: modern clients send
+self-contained requests (no `initialize`, no `Mcp-Session-Id`) and list results
+carry `ttlMs` / `cacheScope`. Legacy stdio clients that still handshake keep
+working. Native Streamable HTTP is available with `MCP_TRANSPORT=streamable-http`
+and is stateless — round-robin load balancing needs no sticky sessions.
+
+See [docs/MIGRATION-0.4.md](docs/MIGRATION-0.4.md) for breaking changes, new
+env vars, and gateway cutover notes. **0.3.4** remains the last release on
+mcp 1.x (`mcp>=1.2.0,<2`).
+
 ## What's New in 0.2.0
 
 **Works with every modern MCP-enabled client we tested.** Strict MCP clients can now discover and call tools — the low-level server advertises correct capabilities and no longer crashes during resource/prompt discovery, and a slow spec download no longer crash-loops short-timeout clients. Verified live against the full list of mainstream agent CLIs:
@@ -128,6 +140,12 @@ Refer to the **Examples** section below for practical configurations tailored to
 - `OPENAPI_SPEC_CACHE_TTL_SECONDS`: (Optional) Live-first disk cache for remote specs: the cached copy is served only when the live fetch fails or stalls (and respawned servers fail fast to it). Default `86400`; set `0` to disable.
 - `ENABLE_TOOLS` / `ENABLE_PROMPTS` / `ENABLE_RESOURCES`: (Optional) Feature gates for the three MCP surfaces in low-level mode; each defaults to enabled. Disabling a feature removes its handlers and its capability advertisement.
 - `CAPABILITIES_TOOLS` / `CAPABILITIES_PROMPTS` / `CAPABILITIES_RESOURCES`: (Optional) Advertise `listChanged` on the corresponding capability (for clients that key on it). Default `false`.
+- `MCP_TRANSPORT`: (Optional) `stdio` (default) or `streamable-http` for native stateless Streamable HTTP (MCP 2026-07-28; no `Mcp-Session-Id`).
+- `MCP_HOST` / `MCP_PORT` / `MCP_PATH`: (Optional) HTTP bind address (`127.0.0.1`), port (`8000`), and path (`/mcp`) when `MCP_TRANSPORT=streamable-http`.
+- `MCP_JSON_RESPONSE`: (Optional) `true` (default) returns JSON instead of SSE on Streamable HTTP.
+- `MCP_LIST_TTL_MS` / `MCP_READ_TTL_MS`: (Optional) `ttlMs` for list results (default `60000`) and `resources/read` (default `5000`).
+- `MCP_ALLOWED_HOSTS`: (Optional) Comma-separated Host allow-list for DNS-rebinding protection. Default `*` (protection off — typical behind nginx).
+- `MCP_REQUEST_STATE_KEY`: (Optional) Shared HMAC key so MRTR `requestState` verifies across instances. Unset = process-local.
 
 ## Verified Clients & Live Results (2026-06-12)
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Refer to the **Examples** section below for practical configurations tailored to
 - `MCP_SERVER_NAME`: (Optional) Identity advertised in `serverInfo` / `server/discover`. Set this to the proxied API (e.g. `gpt-terminal-plus`, `flyio`) so multiple instances are not all called `openapi-proxy`. Falls back to the OpenAPI file stem or spec-URL host, then `openapi-proxy`.
 - `MCP_SERVER_TITLE` / `MCP_SERVER_DESCRIPTION`: (Optional) Display title and description alongside the name.
 - `MCP_TRANSPORT`: (Optional) `stdio` (default) or `streamable-http` for native stateless Streamable HTTP (MCP 2026-07-28; no `Mcp-Session-Id`).
-- `MCP_HOST` / `MCP_PORT` / `MCP_PATH`: (Optional) HTTP bind address (`127.0.0.1`), port (`8000`), and path (`/mcp`) when `MCP_TRANSPORT=streamable-http`.
+- `MCP_HOST` / `MCP_PORT` / `MCP_PATH`: (Optional) HTTP bind address (`127.0.0.1`), port (`8000`), and path (`/mcp`) when `MCP_TRANSPORT=streamable-http`. Native Streamable HTTP also serves `GET /healthz` → `{"ok":true,"name":<MCP_SERVER_NAME or fallback>,"port":<MCP_PORT>}` without taking the MCP request lock (no spec fetch, no `initialize`).
 - `MCP_JSON_RESPONSE`: (Optional) `true` (default) returns JSON instead of SSE on Streamable HTTP.
 - `MCP_LIST_TTL_MS` / `MCP_READ_TTL_MS`: (Optional) `ttlMs` for list results (default `60000`) and `resources/read` (default `5000`).
 - `MCP_ALLOWED_HOSTS`: (Optional) Comma-separated Host allow-list for DNS-rebinding protection. Default `*` (protection off — typical behind nginx).

--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ Refer to the **Examples** section below for practical configurations tailored to
 - `OPENAPI_SPEC_CACHE_TTL_SECONDS`: (Optional) Live-first disk cache for remote specs: the cached copy is served only when the live fetch fails or stalls (and respawned servers fail fast to it). Default `86400`; set `0` to disable.
 - `ENABLE_TOOLS` / `ENABLE_PROMPTS` / `ENABLE_RESOURCES`: (Optional) Feature gates for the three MCP surfaces in low-level mode; each defaults to enabled. Disabling a feature removes its handlers and its capability advertisement.
 - `CAPABILITIES_TOOLS` / `CAPABILITIES_PROMPTS` / `CAPABILITIES_RESOURCES`: (Optional) Advertise `listChanged` on the corresponding capability (for clients that key on it). Default `false`.
+- `MCP_SERVER_NAME`: (Optional) Identity advertised in `serverInfo` / `server/discover`. Set this to the proxied API (e.g. `gpt-terminal-plus`, `flyio`) so multiple instances are not all called `openapi-proxy`. Falls back to the OpenAPI file stem or spec-URL host, then `openapi-proxy`.
+- `MCP_SERVER_TITLE` / `MCP_SERVER_DESCRIPTION`: (Optional) Display title and description alongside the name.
 - `MCP_TRANSPORT`: (Optional) `stdio` (default) or `streamable-http` for native stateless Streamable HTTP (MCP 2026-07-28; no `Mcp-Session-Id`).
 - `MCP_HOST` / `MCP_PORT` / `MCP_PATH`: (Optional) HTTP bind address (`127.0.0.1`), port (`8000`), and path (`/mcp`) when `MCP_TRANSPORT=streamable-http`.
 - `MCP_JSON_RESPONSE`: (Optional) `true` (default) returns JSON instead of SSE on Streamable HTTP.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 **mcp-openapi-proxy** is a Python package that implements a Model Context Protocol (MCP) server, designed to dynamically expose REST APIs—defined by OpenAPI specifications—as MCP tools. This facilitates seamless integration of OpenAPI-described APIs into MCP-based workflows.
 
+**2026-09-05 — 0.4.0:** MCP 2.x / 2026-07-28 native Streamable HTTP (stateless POST /mcp, dual-stack with legacy stdio).
+
 ## What's New in 0.4.0
 
 **MCP 2026-07-28 (SDK 2.x).** The proxy is dual-stack: modern clients send

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ The package offers two operational modes:
 ## Features
 
 - **Dynamic Tool Generation:** Automatically creates MCP tools from OpenAPI endpoint definitions.
+- **Tool Annotations:** Every OpenAPI-derived tool includes MCP `annotations` (`title`, plus `readOnlyHint` / `idempotentHint` for GET and clearly read-ish POST, or `destructiveHint` for other methods) so clients such as Gemini Spark see the same fingerprint as Notion/Linear.
 - **Simple Mode Option:** Offers a static configuration alternative via FastMCP mode.
 - **OpenAPI Specification Support:** Compatible with OpenAPI v3 with potential support for v2.
 - **Flexible Filtering:** Allows endpoint filtering through whitelisting by paths or other criteria.

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Refer to the **Examples** section below for practical configurations tailored to
 - `API_KEY`: (Optional) Authentication token for the API sent as `Bearer <API_KEY>` in the Authorization header by default.
 - `API_AUTH_TYPE`: (Optional) Overrides the default `Bearer` Authorization scheme. `api-key` sends the key in the header named by `API_AUTH_HEADER`; any other value is used as a custom scheme prefix (e.g. `Token` for NetBox → `Authorization: Token <key>`).
 - `STRIP_PARAM`: (Optional) JMESPath expression to strip unwanted parameters (e.g. `token` for Slack).
-- `DEBUG`: (Optional) Enables verbose debug logging when set to "true", "1", or "yes".
+- `DEBUG`: (Optional) Enables verbose debug logging when set to "true", "1", or "yes". Native Streamable HTTP also emits one INFO line per inbound JSON-RPC method (`mcp rpc method=tools/list`, `mcp rpc method=tools/call name=…`) without arguments or Authorization.
 - `EXTRA_HEADERS`: (Optional) One or more outgoing HTTP headers. Accepts a **JSON array** (`["X-A: 1","X-B: 2"]`), one `Header: Value` per **line**, or literal `\n`-separated entries (for configs that cannot embed newlines).
 - `SERVER_URL_OVERRIDE`: (Optional) Overrides the base URL from the OpenAPI specification when set, useful for custom deployments.
 - `TOOL_NAME_MAX_LENGTH`: (Optional) Truncates tool names to a max length.
@@ -1013,7 +1013,7 @@ Then paste these follow-up messages:
 - **Invalid Specification:** Verify the OpenAPI document is standard-compliant.
 - **Tool Filtering Issues:** Check `TOOL_WHITELIST` matches desired endpoints.
 - **Authentication Errors:** Confirm `API_KEY` and `API_AUTH_TYPE` are correct.
-- **Logging:** Set `DEBUG=true` for detailed output to stderr.
+- **Logging:** Set `DEBUG=true` for detailed output to stderr. On native Streamable HTTP (`MCP_TRANSPORT=streamable-http`), INFO always includes `mcp rpc method=…` (and `name=` for `tools/call`) so `POST /mcp 200` can be attributed without enabling DEBUG.
 - **Test Server:** Run directly:
 
 ```bash

--- a/docs/MIGRATION-0.4.md
+++ b/docs/MIGRATION-0.4.md
@@ -53,6 +53,7 @@ for 2026-era clients.
 | `MCP_PORT` | `8000` | HTTP bind port |
 | `MCP_PATH` | `/mcp` | Streamable HTTP path |
 | `GET /healthz` | — | Process-local health JSON on native Streamable HTTP only (`{"ok":true,"name","port"}`). Does not take the MCP request lock. |
+| Streamable HTTP INFO log | — | One line per inbound JSON-RPC POST: `mcp rpc method=tools/list` or `mcp rpc method=tools/call name=…`. No args/Authorization/bodies. |
 | `MCP_JSON_RESPONSE` | `true` | JSON responses instead of SSE |
 | `MCP_LIST_TTL_MS` | `60000` | `ttlMs` for list results |
 | `MCP_READ_TTL_MS` | `5000` | `ttlMs` for `resources/read` |
@@ -133,3 +134,6 @@ legacy HTTP clients, and a 0.4.0 native listener for 2026-era clients.
 | mixed-version (legacy initialize) | `tests/unit/test_mcp2_protocol.py::test_legacy_initialize_still_works` |
 | round-robin, two processes | `tests/integration/test_mcp2_http_roundrobin.py` |
 | GET /healthz body, no spec/lock | `tests/unit/test_healthz.py` |
+| INFO `mcp rpc method=` (no args/secrets) | `tests/unit/test_rpc_logging.py` |
+
+To verify on a live instance: `grep 'mcp rpc method='` in the process stderr (or `servers.log`). `tools/list` logs `mcp rpc method=tools/list`; `tools/call` logs `mcp rpc method=tools/call name=<tool>`. Arguments and `Authorization` must not appear.

--- a/docs/MIGRATION-0.4.md
+++ b/docs/MIGRATION-0.4.md
@@ -1,0 +1,133 @@
+# Migrating to 0.4.0 (MCP 2026-07-28)
+
+0.4.0 ports this proxy from MCP Python SDK 1.x (stateful initialize /
+`Mcp-Session-Id`) to SDK 2.x, which speaks the **2026-07-28** spec. The
+server is dual-stack: modern clients send one self-contained POST; legacy
+stdio clients may still `initialize`.
+
+Issue: [#65](https://github.com/matthewhand/mcp-openapi-proxy/issues/65).
+
+## What you should do
+
+| You | Action |
+|---|---|
+| `uvx mcp-openapi-proxy` / `pip install mcp-openapi-proxy` | Install `>=0.4.0`. Do **not** keep `mcp<2` alongside it. |
+| mcp-gateway / supergateway wrappers | Prefer native `MCP_TRANSPORT=streamable-http` (stateless). Drop `--stateful` and session affinity. See below. |
+| Custom monkeypatches of `dispatcher_handler` | Wrap the function **before** `run_server()`; the Server is rebuilt at start so the wrap is bound into `on_call_tool`. Signature is `(ctx, params)` and still accepts a request-like object with `.params`. |
+| Stay on SDK 1.x | Pin `mcp-openapi-proxy~=0.3.4` and `mcp>=1.2.0,<2`. |
+
+## Protocol (2026-07-28)
+
+Every Streamable HTTP POST is self-contained:
+
+```http
+POST /mcp HTTP/1.1
+Content-Type: application/json
+MCP-Protocol-Version: 2026-07-28
+Mcp-Method: tools/call
+Mcp-Name: get_ping
+
+{"jsonrpc":"2.0","id":1,"method":"tools/call",
+ "params":{"name":"get_ping","arguments":{},
+           "_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28",
+                    "io.modelcontextprotocol/clientInfo":{"name":"app","version":"1.0"},
+                    "io.modelcontextprotocol/clientCapabilities":{}}}}
+```
+
+- **No** `initialize` / `notifications/initialized` required.
+- **No** `Mcp-Session-Id` read or written. Do not configure sticky sessions.
+- Gateways route on `MCP-Protocol-Version`, `Mcp-Method`, `Mcp-Name`.
+- Header/body mismatch is rejected (`-32020`).
+- `tools/list` (and other list/read results) include `ttlMs` and `cacheScope`.
+
+Stdio remains dual-stack: the SDK still answers `initialize` so Codex / Gemini /
+Qwen keep working, and it also answers `server/discover` + per-request `_meta`
+for 2026-era clients.
+
+## New environment variables
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `MCP_TRANSPORT` | `stdio` | `stdio` or `streamable-http` |
+| `MCP_HOST` | `127.0.0.1` | HTTP bind address |
+| `MCP_PORT` | `8000` | HTTP bind port |
+| `MCP_PATH` | `/mcp` | Streamable HTTP path |
+| `MCP_JSON_RESPONSE` | `true` | JSON responses instead of SSE |
+| `MCP_LIST_TTL_MS` | `60000` | `ttlMs` for list results |
+| `MCP_READ_TTL_MS` | `5000` | `ttlMs` for `resources/read` |
+| `MCP_ALLOWED_HOSTS` | `*` | Comma-separated Host allow-list; `*` disables DNS-rebinding protection (typical behind nginx) |
+| `MCP_REQUEST_STATE_KEY` | unset | Shared HMAC for MRTR `requestState` across instances |
+
+## Hidden state moved to explicit handles
+
+Simple mode (`OPENAPI_SIMPLE_MODE=true`) used an in-memory `_FUNCTION_OPERATIONS`
+map filled by `list_functions` and required by `call_function`. That is process
+memory, not a protocol session, but it still broke round-robin: instance B did
+not have instance A's map.
+
+0.4.0:
+
+- `list_functions` returns `handle` (same as `name`) on every entry.
+- `call_function(handle=...)` (or `function_name=`) rebuilds the map from the
+  OpenAPI spec when it is empty. A two-step flow is `list` then `call` with the
+  returned handle; no transport session, no affinity.
+
+Low-level mode already registered tools from the spec on first use; a fresh
+instance that never saw `tools/list` now also rebuilds the registry on
+`tools/call`.
+
+There is no per-connection cursor or job store. Pagination, if added later,
+must travel as a `cursor` argument.
+
+## Breaking behavior changes
+
+1. **mcp 2.x is required.** 0.3.4 was the emergency pin (`mcp<2`) because
+   unpinned 0.3.3 resolved to 2.1.1 and crashed at import. 0.4.0 is the port.
+2. **`FastMCP` import path is gone.** Internal: `mcp.server.mcpserver.MCPServer`.
+   `OPENAPI_SIMPLE_MODE=true` still selects simple mode.
+3. **Resource URIs are strings**, not pydantic `AnyUrl`. Relative URIs are legal.
+4. **Python attributes are snake_case** (`input_schema`, `is_error`, `mime_type`,
+   `list_changed`). JSON-RPC on the wire is still camelCase.
+5. **Low-level `Server.request_handlers` dict is gone.** Handlers are `on_*`
+   constructor kwargs. `run_server()` rebuilds the Server so a wrap of
+   `dispatcher_handler` still works.
+6. **Tool handler exceptions** that escape `dispatcher_handler` are JSON-RPC
+   errors, not `isError: true` results. The dispatcher still catches and
+   returns `CallToolResult` for API/request errors.
+7. **Streamable HTTP is stateless.** `Mcp-Session-Id` is never required or
+   emitted. A load balancer may round-robin every POST.
+8. **Modern clients against 0.3.x fail.** A 2026-07-28 client that does not
+   fall back to `initialize` cannot talk to a 1.x-only server. Run 0.4.0 or
+   keep a dual-stack gateway.
+
+## Gateway / remote HTTP
+
+Replace:
+
+```bash
+npx supergateway --stdio "uvx mcp-openapi-proxy" \
+  --outputTransport streamableHttp --stateful --sessionTimeout 3600000
+```
+
+with:
+
+```bash
+env MCP_TRANSPORT=streamable-http MCP_HOST=127.0.0.1 MCP_PORT=$PORT \
+  uvx mcp-openapi-proxy
+```
+
+Keep nginx in front for TLS/OAuth. Do **not** enable session affinity.
+
+Temporary dual-stack: leave a 0.3.4+supergateway `--stateful` listener for
+legacy HTTP clients, and a 0.4.0 native listener for 2026-era clients.
+
+## Acceptance tests
+
+| Test | File |
+|---|---|
+| tools/list, no handshake | `tests/unit/test_mcp2_protocol.py`, `tests/integration/test_client_discovery.py` |
+| tools/call, no `Mcp-Session-Id` | `tests/unit/test_mcp2_protocol.py` |
+| two-step via explicit handle | `tests/unit/test_mcp2_protocol.py::test_fastmcp_two_step_uses_explicit_handle` |
+| retries / duplicate ids | `tests/unit/test_mcp2_protocol.py::test_http_duplicate_request_ids_are_independent` |
+| mixed-version (legacy initialize) | `tests/unit/test_mcp2_protocol.py::test_legacy_initialize_still_works` |
+| round-robin, two processes | `tests/integration/test_mcp2_http_roundrobin.py` |

--- a/docs/MIGRATION-0.4.md
+++ b/docs/MIGRATION-0.4.md
@@ -52,6 +52,7 @@ for 2026-era clients.
 | `MCP_HOST` | `127.0.0.1` | HTTP bind address |
 | `MCP_PORT` | `8000` | HTTP bind port |
 | `MCP_PATH` | `/mcp` | Streamable HTTP path |
+| `GET /healthz` | — | Process-local health JSON on native Streamable HTTP only (`{"ok":true,"name","port"}`). Does not take the MCP request lock. |
 | `MCP_JSON_RESPONSE` | `true` | JSON responses instead of SSE |
 | `MCP_LIST_TTL_MS` | `60000` | `ttlMs` for list results |
 | `MCP_READ_TTL_MS` | `5000` | `ttlMs` for `resources/read` |
@@ -131,3 +132,4 @@ legacy HTTP clients, and a 0.4.0 native listener for 2026-era clients.
 | retries / duplicate ids | `tests/unit/test_mcp2_protocol.py::test_http_duplicate_request_ids_are_independent` |
 | mixed-version (legacy initialize) | `tests/unit/test_mcp2_protocol.py::test_legacy_initialize_still_works` |
 | round-robin, two processes | `tests/integration/test_mcp2_http_roundrobin.py` |
+| GET /healthz body, no spec/lock | `tests/unit/test_healthz.py` |

--- a/docs/MIGRATION-0.4.md
+++ b/docs/MIGRATION-0.4.md
@@ -39,6 +39,8 @@ Mcp-Name: get_ping
 - Gateways route on `MCP-Protocol-Version`, `Mcp-Method`, `Mcp-Name`.
 - Header/body mismatch is rejected (`-32020`).
 - `tools/list` (and other list/read results) include `ttlMs` and `cacheScope`.
+- Each OpenAPI-derived tool includes MCP `annotations` (`title` plus
+  method-derived `readOnlyHint` / `idempotentHint` or `destructiveHint`).
 
 Stdio remains dual-stack: the SDK still answers `initialize` so Codex / Gemini /
 Qwen keep working, and it also answers `server/discover` + per-request `_meta`

--- a/mcp_openapi_proxy/handlers.py
+++ b/mcp_openapi_proxy/handlers.py
@@ -6,13 +6,11 @@ import os
 import json
 from typing import Any, Dict, List, Union
 from types import SimpleNamespace
-from pydantic import AnyUrl
 
 import requests
 from mcp import types
-from mcp.server.models import InitializationOptions
-from mcp.server.stdio import stdio_server
 from mcp_openapi_proxy.logging_setup import logger
+from mcp_openapi_proxy.protocol import unpack_handler_args
 from mcp_openapi_proxy.utils import (
     normalize_tool_name,
     is_tool_whitelisted,
@@ -35,13 +33,14 @@ prompts: List[types.Prompt] = []
 openapi_spec_data = None
 
 
-async def dispatcher_handler(request: types.CallToolRequest) -> Any:
+async def dispatcher_handler(ctx_or_request: Any, params: Any = None) -> Any:
     """
     Dispatcher handler that routes CallToolRequest to the appropriate function (tool).
     """
     global openapi_spec_data
+    _, params = unpack_handler_args(ctx_or_request, params)
     try:
-        function_name = request.params.name
+        function_name = params.name
         logger.debug(f"Dispatcher received CallToolRequest for function: {function_name}")
         api_key = os.getenv("API_KEY")
         logger.debug(f"API_KEY: {api_key[:5] + '...' if api_key else '<not set>'}")
@@ -51,16 +50,16 @@ async def dispatcher_handler(request: types.CallToolRequest) -> Any:
             logger.error(f"Unknown function requested: {function_name}")
             result = types.CallToolResult(
                 content=[types.TextContent(type="text", text="Unknown function requested")],
-                isError=False,
+                is_error=False,
             )
             return result
-        arguments = request.params.arguments or {}
+        arguments = params.arguments or {}
         logger.debug(f"Raw arguments before processing: {arguments}")
 
         if openapi_spec_data is None:
             result = types.CallToolResult(
                 content=[types.TextContent(type="text", text="OpenAPI spec not loaded")],
-                isError=True,
+                is_error=True,
             )
             return result
         operation_details = lookup_operation_details(function_name, openapi_spec_data)
@@ -68,7 +67,7 @@ async def dispatcher_handler(request: types.CallToolRequest) -> Any:
             logger.error(f"Could not find OpenAPI operation for function: {function_name}")
             result = types.CallToolResult(
                 content=[types.TextContent(type="text", text=f"Could not find OpenAPI operation for function: {function_name}")],
-                isError=False,
+                is_error=False,
             )
             return result
 
@@ -98,7 +97,7 @@ async def dispatcher_handler(request: types.CallToolRequest) -> Any:
             logger.error(f"Missing parameter for substitution: {e}")
             result = types.CallToolResult(
                 content=[types.TextContent(type="text", text=f"Missing parameter: {e}")],
-                isError=False,
+                is_error=False,
             )
             return result
 
@@ -107,7 +106,7 @@ async def dispatcher_handler(request: types.CallToolRequest) -> Any:
             logger.critical("Failed to construct base URL from spec or SERVER_URL_OVERRIDE.")
             result = types.CallToolResult(
                 content=[types.TextContent(type="text", text="No base URL defined in spec or SERVER_URL_OVERRIDE")],
-                isError=False,
+                is_error=False,
             )
             return result
 
@@ -132,7 +131,7 @@ async def dispatcher_handler(request: types.CallToolRequest) -> Any:
                     logger.error(f"Missing required path parameters: {missing_required}")
                     result = types.CallToolResult(
                         content=[types.TextContent(type="text", text=f"Missing required path parameters: {missing_required}")],
-                        isError=False,
+                        is_error=False,
                     )
                     return result
             if method == "GET":
@@ -163,29 +162,29 @@ async def dispatcher_handler(request: types.CallToolRequest) -> Any:
             response_text = (response.text or "No response body").strip()
             content, log_message = detect_response_type(response_text)
             logger.debug(log_message)
-            final_content = [content.dict()]
+            final_content = [content]
         except requests.exceptions.RequestException as e:
             logger.error(f"API request failed: {e}")
             result = types.CallToolResult(
                 content=[types.TextContent(type="text", text=str(e))],
-                isError=False,
+                is_error=False,
             )
             return result
 
         logger.debug(f"Response content type: {content.type}")
         logger.debug(f"Response sent to client: {content.text}")
-        result = types.CallToolResult(content=final_content, isError=False)  # type: ignore
+        result = types.CallToolResult(content=final_content, is_error=False)
         return result
     except Exception as e:
         logger.error(f"Unhandled exception in dispatcher_handler: {e}", exc_info=True)
         result = types.CallToolResult(
             content=[types.TextContent(type="text", text=f"Internal error: {str(e)}")],
-            isError=False,
+            is_error=False,
         )
         return result
 
 
-async def list_tools(request: types.ListToolsRequest) -> Any:
+async def list_tools(ctx_or_request: Any = None, params: Any = None) -> Any:
     """Return a list of registered tools."""
     logger.debug("Handling list_tools request - start")
     logger.debug(f"Tools list length: {len(tools)}")
@@ -193,7 +192,7 @@ async def list_tools(request: types.ListToolsRequest) -> Any:
     return result
 
 
-async def list_resources(request: types.ListResourcesRequest) -> Any:
+async def list_resources(ctx_or_request: Any = None, params: Any = None) -> Any:
     """Return a list of registered resources."""
     logger.debug("Handling list_resources request")
     if not resources:
@@ -202,7 +201,7 @@ async def list_resources(request: types.ListResourcesRequest) -> Any:
         resources.append(
             types.Resource(
                 name="spec_file",
-                uri=AnyUrl("file:///openapi_spec.json"),
+                uri="file:///openapi_spec.json",
                 description="The raw OpenAPI specification JSON",
             )
         )
@@ -211,9 +210,11 @@ async def list_resources(request: types.ListResourcesRequest) -> Any:
     return result
 
 
-async def read_resource(request: types.ReadResourceRequest) -> Any:
+async def read_resource(ctx_or_request: Any, params: Any = None) -> Any:
     """Read a specific resource identified by its URI."""
-    logger.debug(f"START read_resource for URI: {request.params.uri}")
+    _, params = unpack_handler_args(ctx_or_request, params)
+    uri_str = str(params.uri)
+    logger.debug(f"START read_resource for URI: {uri_str}")
     try:
         global openapi_spec_data
         spec_data = openapi_spec_data
@@ -227,7 +228,7 @@ async def read_resource(request: types.ReadResourceRequest) -> Any:
                     contents=[
                         types.TextResourceContents(
                             text="Spec unavailable: OPENAPI_SPEC_URL not set and no spec data loaded",
-                            uri=AnyUrl(str(request.params.uri)),
+                            uri=uri_str,
                         )
                     ]
                 )
@@ -244,7 +245,7 @@ async def read_resource(request: types.ReadResourceRequest) -> Any:
                 contents=[
                     types.TextResourceContents(
                         text="Spec data unavailable after fetch attempt",
-                        uri=AnyUrl(str(request.params.uri)),
+                        uri=uri_str,
                     )
                 ]
             )
@@ -256,8 +257,8 @@ async def read_resource(request: types.ReadResourceRequest) -> Any:
             contents=[
                 types.TextResourceContents(
                     text=spec_json,
-                    uri=AnyUrl("file:///openapi_spec.json"),
-                    mimeType="application/json"
+                    uri="file:///openapi_spec.json",
+                    mime_type="application/json"
                 )
             ]
         )
@@ -268,14 +269,14 @@ async def read_resource(request: types.ReadResourceRequest) -> Any:
         result = types.ReadResourceResult(
             contents=[
                 types.TextResourceContents(
-                    text=f"Resource error: {str(e)}", uri=request.params.uri
+                    text=f"Resource error: {str(e)}", uri=uri_str
                 )
             ]
         )
         return result
 
 
-async def list_prompts(request: types.ListPromptsRequest) -> Any:
+async def list_prompts(ctx_or_request: Any = None, params: Any = None) -> Any:
     """Return a list of registered prompts."""
     logger.debug("Handling list_prompts request")
     logger.debug(f"Prompts list length: {len(prompts)}")
@@ -283,12 +284,14 @@ async def list_prompts(request: types.ListPromptsRequest) -> Any:
     return result
 
 
-async def get_prompt(request: types.GetPromptRequest) -> Any:
+async def get_prompt(ctx_or_request: Any, params: Any = None) -> Any:
     """Return a specific prompt by name."""
-    logger.debug(f"Handling get_prompt request for {request.params.name}")
-    prompt = next((p for p in prompts if p.name == request.params.name), None)
+    _, params = unpack_handler_args(ctx_or_request, params)
+    name = params.name
+    logger.debug(f"Handling get_prompt request for {name}")
+    prompt = next((p for p in prompts if p.name == name), None)
     if not prompt:
-        logger.error(f"Prompt '{request.params.name}' not found")
+        logger.error(f"Prompt '{name}' not found")
         result = types.GetPromptResult(
             messages=[
                 types.PromptMessage(

--- a/mcp_openapi_proxy/openapi.py
+++ b/mcp_openapi_proxy/openapi.py
@@ -7,7 +7,7 @@ import json
 import re # Import the re module
 import requests
 import yaml
-from typing import Dict, Optional, List, Union
+from typing import Dict, Optional, List, Union, Set
 from urllib.parse import unquote, quote
 from mcp import types
 from mcp_openapi_proxy.utils import normalize_tool_name
@@ -15,6 +15,114 @@ from .logging_setup import logger
 
 # Define the required tool name pattern
 TOOL_NAME_REGEX = r"^[a-zA-Z0-9_-]{1,64}$"
+
+# First-token / token sets used to treat a POST as read-ish (search/query/list).
+# Write tokens win so getOrCreate / searchAndCreate stay destructive.
+_READISH_TOKENS = frozenset({
+    "get", "list", "search", "query", "find", "fetch", "filter",
+    "lookup", "read", "count", "exists", "check", "status", "ping",
+    "health", "describe", "show", "view",
+})
+_WRITE_TOKENS = frozenset({
+    "create", "update", "delete", "post", "put", "patch", "add",
+    "remove", "set", "send", "write", "upsert",
+})
+_SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS", "TRACE"})
+_IDEMPOTENT_WRITE_METHODS = frozenset({"PUT", "DELETE"})
+
+
+def _identifier_tokens(text: str) -> List[str]:
+    """Split camelCase / snake_case / kebab-case into lowercase tokens."""
+    if not text:
+        return []
+    spaced = re.sub(r"(?<=[a-z0-9])([A-Z])", r" \1", text)
+    spaced = spaced.replace("_", " ").replace("-", " ")
+    return [part.lower() for part in re.findall(r"[A-Za-z0-9]+", spaced)]
+
+
+def human_tool_title(tool_name: str, operation: Optional[Dict] = None) -> str:
+    """Human title for annotations.title: short summary, else operationId, else tool name."""
+    operation = operation or {}
+    summary = operation.get("summary")
+    if isinstance(summary, str):
+        summary = summary.strip()
+        if summary and len(summary) <= 80:
+            return summary
+    op_id = operation.get("operationId")
+    if isinstance(op_id, str) and op_id.strip():
+        return _humanize_identifier(op_id)
+    return _humanize_identifier(tool_name)
+
+
+def _humanize_identifier(name: str) -> str:
+    tokens = _identifier_tokens(name)
+    if not tokens:
+        return name
+    return " ".join(token[:1].upper() + token[1:] for token in tokens)
+
+
+def _is_readish_post(operation: Optional[Dict]) -> bool:
+    """True when a POST looks like search/query/list rather than a write."""
+    operation = operation or {}
+    texts = []
+    for key in ("operationId", "summary"):
+        val = operation.get(key)
+        if isinstance(val, str) and val.strip():
+            texts.append(val)
+    if not texts:
+        return False
+    tokens: Set[str] = set()
+    first_tokens: List[str] = []
+    for text in texts:
+        parts = _identifier_tokens(text)
+        tokens.update(parts)
+        if parts:
+            first_tokens.append(parts[0])
+    if tokens & _WRITE_TOKENS:
+        return False
+    return any(first in _READISH_TOKENS for first in first_tokens)
+
+
+def build_tool_annotations(
+    method: Optional[str],
+    tool_name: str,
+    operation: Optional[Dict] = None,
+    *,
+    read_only: Optional[bool] = None,
+) -> types.ToolAnnotations:
+    """MCP ToolAnnotations derived from the OpenAPI HTTP method (Notion pattern).
+
+    GET/HEAD/OPTIONS (and clearly read-ish POST) set readOnlyHint + idempotentHint.
+    Other methods set destructiveHint; PUT/DELETE also set idempotentHint.
+    """
+    title = human_tool_title(tool_name, operation)
+    method_upper = (method or "").upper()
+    if read_only is True or method_upper in _SAFE_METHODS or (
+        method_upper == "POST" and _is_readish_post(operation)
+    ):
+        return types.ToolAnnotations(
+            title=title,
+            read_only_hint=True,
+            idempotent_hint=True,
+        )
+    return types.ToolAnnotations(
+        title=title,
+        destructive_hint=True,
+        idempotent_hint=True if method_upper in _IDEMPOTENT_WRITE_METHODS else None,
+    )
+
+
+def annotations_wire_dict(
+    method: Optional[str],
+    tool_name: str,
+    operation: Optional[Dict] = None,
+    *,
+    read_only: Optional[bool] = None,
+) -> Dict:
+    """CamelCase annotations object for JSON tools/list (and simple-mode catalogs)."""
+    return build_tool_annotations(
+        method, tool_name, operation, read_only=read_only
+    ).model_dump(by_alias=True, exclude_none=True)
 
 def fetch_openapi_spec(url: str, retries: int = 3) -> Optional[Dict]:
     """Fetch and parse an OpenAPI specification from a URL with retries."""
@@ -294,11 +402,16 @@ def register_functions(spec: Dict) -> List[types.Tool]:
                                #         input_schema['required'].append('body')
 
 
-                # Create and register the tool
+                # Create and register the tool. Annotations follow MCP ToolAnnotations
+                # (title + method-derived hints) so clients such as Gemini Spark see
+                # the same fingerprint as Notion/Linear.
+                annotations = build_tool_annotations(method, function_name, operation)
                 tool = types.Tool(
                     name=function_name,
+                    title=annotations.title,
                     description=description,
                     inputSchema=input_schema,
+                    annotations=annotations,
                 )
                 tools_list.append(tool)
                 registered_names.add(function_name)

--- a/mcp_openapi_proxy/protocol.py
+++ b/mcp_openapi_proxy/protocol.py
@@ -1,0 +1,162 @@
+"""Shared MCP 2026-07-28 helpers for both server modes.
+
+The proxy is a dual-stack server:
+- 2026-07-28 clients send self-contained requests (no initialize, no session).
+- Legacy 2025-era clients may still perform initialize over stdio; the SDK
+  answers that handshake alongside server/discover.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Mapping, Optional, Tuple
+
+PACKAGE_VERSION = "0.4.0"
+SERVER_VERSION = PACKAGE_VERSION
+PROTOCOL_VERSION_MODERN = "2026-07-28"
+PROTOCOL_VERSION_LEGACY = "2025-11-25"
+
+DEFAULT_LIST_TTL_MS = 60_000
+DEFAULT_READ_TTL_MS = 5_000
+
+HEADER_PROTOCOL_VERSION = "MCP-Protocol-Version"
+HEADER_METHOD = "Mcp-Method"
+HEADER_NAME = "Mcp-Name"
+HEADER_SESSION_ID = "Mcp-Session-Id"
+
+
+def truthy(name: str, default: bool = False) -> bool:
+    val = os.getenv(name)
+    if val is None:
+        return default
+    return val.strip().lower() in ("true", "1", "yes")
+
+
+def env_int(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return value if value >= 0 else default
+
+
+def unpack_handler_args(ctx_or_request: Any, params: Any = None) -> Tuple[Any, Any]:
+    """Accept v2 ``(ctx, params)`` or the older request-with-``.params`` object.
+
+    Unit tests and the gateway query-auth wrapper historically called handlers
+    with a single request object. Keep that working so monkeypatches and tests
+    do not have to special-case the SDK era.
+    """
+    if params is not None:
+        return ctx_or_request, params
+    req = ctx_or_request
+    if req is not None and hasattr(req, "params"):
+        return None, req.params
+    return None, req
+
+
+def transport_name() -> str:
+    raw = os.getenv("MCP_TRANSPORT", "stdio").strip().lower().replace("_", "-")
+    if raw in ("http", "streamable-http", "streamablehttp"):
+        return "streamable-http"
+    return "stdio"
+
+
+def mcp_host() -> str:
+    return os.getenv("MCP_HOST", "127.0.0.1")
+
+
+def mcp_port() -> int:
+    return env_int("MCP_PORT", 8000)
+
+
+def mcp_path() -> str:
+    path = os.getenv("MCP_PATH", "/mcp").strip() or "/mcp"
+    if not path.startswith("/"):
+        path = "/" + path
+    return path
+
+
+def list_ttl_ms() -> int:
+    return env_int("MCP_LIST_TTL_MS", DEFAULT_LIST_TTL_MS)
+
+
+def read_ttl_ms() -> int:
+    return env_int("MCP_READ_TTL_MS", DEFAULT_READ_TTL_MS)
+
+
+def json_response() -> bool:
+    return truthy("MCP_JSON_RESPONSE", True)
+
+
+def transport_security():
+    """DNS-rebinding settings for Streamable HTTP.
+
+    Default is protection off so the server can sit behind nginx (the public
+    Host header is not 127.0.0.1). Set MCP_ALLOWED_HOSTS to a comma-separated
+    allow-list to turn protection back on.
+    """
+    from mcp.server.transport_security import TransportSecuritySettings
+
+    hosts = os.getenv("MCP_ALLOWED_HOSTS", "*").strip()
+    if hosts in ("*", ""):
+        return TransportSecuritySettings(enable_dns_rebinding_protection=False)
+    return TransportSecuritySettings(
+        enable_dns_rebinding_protection=True,
+        allowed_hosts=[h.strip() for h in hosts.split(",") if h.strip()],
+        allowed_origins=["*"],
+    )
+
+
+def request_state_security():
+    """Optional shared HMAC key so MRTR requestState works across instances.
+
+    Unset MCP_REQUEST_STATE_KEY keeps the SDK process-local default. A shared
+    key is required for multi-instance round-robin of mid-call elicitation.
+    """
+    from mcp.server.request_state import RequestStateSecurity
+
+    key = os.getenv("MCP_REQUEST_STATE_KEY")
+    if not key:
+        return None
+    return RequestStateSecurity(keys=[key])
+
+
+def cache_hints() -> Mapping[str, Any]:
+    from mcp.server import CacheHint
+
+    ttl = list_ttl_ms()
+    return {
+        "tools/list": CacheHint(ttl_ms=ttl, scope="public"),
+        "prompts/list": CacheHint(ttl_ms=ttl, scope="public"),
+        "resources/list": CacheHint(ttl_ms=ttl, scope="public"),
+        "resources/templates/list": CacheHint(ttl_ms=ttl, scope="public"),
+        "resources/read": CacheHint(ttl_ms=read_ttl_ms(), scope="private"),
+        "server/discover": CacheHint(ttl_ms=ttl, scope="public"),
+    }
+
+
+def modern_request_meta(
+    client_name: str = "mcp-openapi-proxy-test",
+    client_version: str = "0",
+) -> dict:
+    return {
+        "io.modelcontextprotocol/protocolVersion": PROTOCOL_VERSION_MODERN,
+        "io.modelcontextprotocol/clientInfo": {"name": client_name, "version": client_version},
+        "io.modelcontextprotocol/clientCapabilities": {},
+    }
+
+
+def modern_headers(method: str, name: Optional[str] = None) -> dict:
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+        HEADER_PROTOCOL_VERSION: PROTOCOL_VERSION_MODERN,
+        HEADER_METHOD: method,
+    }
+    if name:
+        headers[HEADER_NAME] = name
+    return headers

--- a/mcp_openapi_proxy/protocol.py
+++ b/mcp_openapi_proxy/protocol.py
@@ -65,6 +65,45 @@ def transport_name() -> str:
     return "stdio"
 
 
+def advertised_server_name() -> str:
+    """Identity reported in serverInfo / initialize / server/discover.
+
+    Prefer an explicit MCP_SERVER_NAME (gateway instances set this to the
+    proxied API: flyio, gpt-terminal-plus, …). Otherwise derive a stable
+    slug from OPENAPI_SPEC_URL so two uvx processes are not both called
+    OpenApiProxy-LowLevel.
+    """
+    explicit = (os.getenv("MCP_SERVER_NAME") or os.getenv("OPENAPI_SERVER_NAME") or "").strip()
+    if explicit:
+        return explicit
+    url = (os.getenv("OPENAPI_SPEC_URL") or "").strip()
+    if url.startswith("file://"):
+        from pathlib import Path
+
+        stem = Path(url[7:].split("?", 1)[0]).stem
+        if stem and stem not in (".",):
+            return stem
+    elif "://" in url:
+        from urllib.parse import urlparse
+
+        host = (urlparse(url).hostname or "").lower()
+        if host.startswith("www."):
+            host = host[4:]
+        if host:
+            return host
+    return "openapi-proxy"
+
+
+def advertised_server_title() -> Optional[str]:
+    title = (os.getenv("MCP_SERVER_TITLE") or "").strip()
+    return title or None
+
+
+def advertised_server_description() -> Optional[str]:
+    desc = (os.getenv("MCP_SERVER_DESCRIPTION") or "").strip()
+    return desc or None
+
+
 def mcp_host() -> str:
     return os.getenv("MCP_HOST", "127.0.0.1")
 

--- a/mcp_openapi_proxy/protocol.py
+++ b/mcp_openapi_proxy/protocol.py
@@ -8,8 +8,14 @@ The proxy is a dual-stack server:
 
 from __future__ import annotations
 
+import json
+import logging
 import os
+import re
+from collections import deque
 from typing import Any, Mapping, Optional, Tuple
+
+logger = logging.getLogger("mcp_openapi_proxy")
 
 PACKAGE_VERSION = "0.4.0"
 SERVER_VERSION = PACKAGE_VERSION
@@ -23,6 +29,11 @@ HEADER_PROTOCOL_VERSION = "MCP-Protocol-Version"
 HEADER_METHOD = "Mcp-Method"
 HEADER_NAME = "Mcp-Name"
 HEADER_SESSION_ID = "Mcp-Session-Id"
+
+# JSON-RPC method / tools/call name only. Reject anything that could smuggle
+# tokens or extra fields into the one-line INFO log.
+_RPC_TOKEN_RE = re.compile(r"^[A-Za-z0-9_./:-]{1,128}$")
+_RPC_NAME_METHODS = frozenset({"tools/call"})
 
 
 def truthy(name: str, default: bool = False) -> bool:
@@ -143,6 +154,124 @@ def healthz_route():
     from starlette.routing import Route
 
     return Route(HEALTHZ_PATH, endpoint=healthz_endpoint, methods=["GET"])
+
+
+def _safe_rpc_token(value: Any) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    token = value.strip()
+    if not token or not _RPC_TOKEN_RE.fullmatch(token):
+        return None
+    return token
+
+
+def inbound_rpc_identity(
+    payload: Any = None,
+    headers: Optional[Mapping[str, str]] = None,
+) -> Tuple[Optional[str], Optional[str]]:
+    """JSON-RPC method and tools/call name only. Never reads arguments/bodies."""
+    method: Optional[str] = None
+    name: Optional[str] = None
+    if isinstance(payload, dict):
+        method = _safe_rpc_token(payload.get("method"))
+        params = payload.get("params")
+        if isinstance(params, dict):
+            name = _safe_rpc_token(params.get("name"))
+    if headers:
+        folded = {str(key).lower(): headers[key] for key in headers}
+        if method is None:
+            method = _safe_rpc_token(folded.get("mcp-method"))
+        if name is None:
+            name = _safe_rpc_token(folded.get("mcp-name"))
+    return method, name
+
+
+def format_rpc_log_line(method: Optional[str], name: Optional[str] = None) -> Optional[str]:
+    """One INFO line: ``mcp rpc method=tools/list`` or ``... method=tools/call name=...``."""
+    method = _safe_rpc_token(method)
+    if not method:
+        return None
+    if method in _RPC_NAME_METHODS:
+        name = _safe_rpc_token(name)
+        if name:
+            return f"mcp rpc method={method} name={name}"
+    return f"mcp rpc method={method}"
+
+
+def log_inbound_rpc(method: Optional[str], name: Optional[str] = None) -> Optional[str]:
+    line = format_rpc_log_line(method, name)
+    if line:
+        logger.info(line)
+    return line
+
+
+class McpRpcLogMiddleware:
+    """Raw ASGI wrapper: log inbound JSON-RPC method before StreamableHTTPSessionManager.
+
+    Not BaseHTTPMiddleware — that class can interfere with Streamable HTTP
+    streaming. Only POST bodies are peeked; Authorization and ``arguments``
+    are never logged.
+    """
+
+    def __init__(self, app: Any):
+        self.app = app
+
+    async def __call__(self, scope: Any, receive: Any, send: Any) -> None:
+        if scope.get("type") != "http" or scope.get("method") != "POST":
+            await self.app(scope, receive, send)
+            return
+        body, replay = await _buffer_http_body(receive)
+        method, name = inbound_rpc_identity(_try_json_rpc(body), _asgi_header_map(scope))
+        log_inbound_rpc(method, name)
+        await self.app(scope, replay, send)
+
+
+def _asgi_header_map(scope: Mapping[str, Any]) -> dict[str, str]:
+    headers: dict[str, str] = {}
+    for raw_key, raw_value in scope.get("headers") or ():
+        try:
+            key = raw_key.decode("latin-1").lower()
+            value = raw_value.decode("latin-1")
+        except (AttributeError, UnicodeDecodeError):
+            continue
+        if key == "authorization":
+            continue
+        headers[key] = value
+    return headers
+
+
+def _try_json_rpc(body: bytes) -> Any:
+    if not body:
+        return None
+    try:
+        return json.loads(body)
+    except (ValueError, RecursionError, UnicodeDecodeError):
+        return None
+
+
+async def _buffer_http_body(receive: Any) -> Tuple[bytes, Any]:
+    """Read the POST body once and replay it to StreamableHTTPSessionManager."""
+    chunks = bytearray()
+    trailing = None
+    while True:
+        message = await receive()
+        if message["type"] != "http.request":
+            trailing = message
+            break
+        chunks.extend(message.get("body") or b"")
+        if not message.get("more_body", False):
+            break
+    cached: deque = deque()
+    cached.append({"type": "http.request", "body": bytes(chunks), "more_body": False})
+    if trailing is not None:
+        cached.append(trailing)
+
+    async def replay() -> Any:
+        if cached:
+            return cached.popleft()
+        return await receive()
+
+    return bytes(chunks), replay
 
 
 def list_ttl_ms() -> int:

--- a/mcp_openapi_proxy/protocol.py
+++ b/mcp_openapi_proxy/protocol.py
@@ -119,6 +119,32 @@ def mcp_path() -> str:
     return path
 
 
+HEALTHZ_PATH = "/healthz"
+
+
+def healthz_body() -> dict:
+    """Process-local health payload. Env only — no spec fetch, no MCP I/O."""
+    return {
+        "ok": True,
+        "name": advertised_server_name(),
+        "port": mcp_port(),
+    }
+
+
+async def healthz_endpoint(request: Any):
+    """Starlette handler for GET /healthz. Does not enter the MCP request lock."""
+    from starlette.responses import JSONResponse
+
+    return JSONResponse(healthz_body())
+
+
+def healthz_route():
+    """Sibling Starlette Route — not mounted under StreamableHTTPSessionManager."""
+    from starlette.routing import Route
+
+    return Route(HEALTHZ_PATH, endpoint=healthz_endpoint, methods=["GET"])
+
+
 def list_ttl_ms() -> int:
     return env_int("MCP_LIST_TTL_MS", DEFAULT_LIST_TTL_MS)
 

--- a/mcp_openapi_proxy/server_fastmcp.py
+++ b/mcp_openapi_proxy/server_fastmcp.py
@@ -21,6 +21,9 @@ from mcp_openapi_proxy.openapi import fetch_openapi_spec, build_base_url, handle
 from mcp_openapi_proxy.utils import is_tool_whitelisted, normalize_tool_name, strip_parameters, get_additional_headers, deduplicate_tool_name
 from mcp_openapi_proxy.protocol import (
     PACKAGE_VERSION,
+    advertised_server_description,
+    advertised_server_name,
+    advertised_server_title,
     cache_hints,
     json_response,
     mcp_host,
@@ -38,8 +41,10 @@ import sys
 logger.debug(f"Server CWD: {os.getcwd()}")
 
 mcp = MCPServer(
-    "OpenApiProxy-Fast",
+    advertised_server_name(),
     version=PACKAGE_VERSION,
+    title=advertised_server_title(),
+    description=advertised_server_description(),
     cache_hints=cache_hints(),
     request_state_security=request_state_security(),
 )

--- a/mcp_openapi_proxy/server_fastmcp.py
+++ b/mcp_openapi_proxy/server_fastmcp.py
@@ -20,11 +20,13 @@ from mcp_openapi_proxy.logging_setup import logger
 from mcp_openapi_proxy.openapi import fetch_openapi_spec, build_base_url, handle_auth
 from mcp_openapi_proxy.utils import is_tool_whitelisted, normalize_tool_name, strip_parameters, get_additional_headers, deduplicate_tool_name
 from mcp_openapi_proxy.protocol import (
+    HEALTHZ_PATH,
     PACKAGE_VERSION,
     advertised_server_description,
     advertised_server_name,
     advertised_server_title,
     cache_hints,
+    healthz_endpoint,
     json_response,
     mcp_host,
     mcp_path,
@@ -48,6 +50,8 @@ mcp = MCPServer(
     cache_hints=cache_hints(),
     request_state_security=request_state_security(),
 )
+# Sibling Starlette route: process-local /healthz, no MCP lock (issue #66).
+mcp.custom_route(HEALTHZ_PATH, methods=["GET"])(healthz_endpoint)
 
 spec = None  # Global spec for resources
 

--- a/mcp_openapi_proxy/server_fastmcp.py
+++ b/mcp_openapi_proxy/server_fastmcp.py
@@ -17,7 +17,13 @@ import requests
 from typing import Dict, Any, Optional
 from mcp.server.mcpserver import MCPServer
 from mcp_openapi_proxy.logging_setup import logger
-from mcp_openapi_proxy.openapi import fetch_openapi_spec, build_base_url, handle_auth
+from mcp import types as mcp_types
+from mcp_openapi_proxy.openapi import (
+    annotations_wire_dict,
+    fetch_openapi_spec,
+    build_base_url,
+    handle_auth,
+)
 from mcp_openapi_proxy.utils import is_tool_whitelisted, normalize_tool_name, strip_parameters, get_additional_headers, deduplicate_tool_name
 from mcp_openapi_proxy.protocol import (
     HEALTHZ_PATH,
@@ -109,7 +115,14 @@ def _whimsical_blog_prompt() -> str:
             "✨ Write the next whimsical chapter.")
 
 
-@mcp.tool()
+@mcp.tool(
+    title="List Functions",
+    annotations=mcp_types.ToolAnnotations(
+        title="List Functions",
+        read_only_hint=True,
+        idempotent_hint=True,
+    ),
+)
 def list_functions(*, env_key: str = "OPENAPI_SPEC_URL") -> str:
     """Lists available functions derived from the OpenAPI specification."""
     logger.debug("Executing list_functions tool.")
@@ -224,7 +237,8 @@ def list_functions(*, env_key: str = "OPENAPI_SPEC_URL") -> str:
                 "method": method.upper(),
                 "operationId": operation.get("operationId"),
                 "original_name": raw_name,
-                "inputSchema": input_schema
+                "inputSchema": input_schema,
+                "annotations": annotations_wire_dict(method, function_name, operation),
             }
             _FUNCTION_OPERATIONS[function_name] = {
                 "path": path,
@@ -239,7 +253,8 @@ def list_functions(*, env_key: str = "OPENAPI_SPEC_URL") -> str:
         "method": None,
         "operationId": None,
         "original_name": "list_resources",
-        "inputSchema": {"type": "object", "properties": {}, "required": [], "additionalProperties": False}
+        "inputSchema": {"type": "object", "properties": {}, "required": [], "additionalProperties": False},
+        "annotations": annotations_wire_dict(None, "list_resources", read_only=True),
     }
     functions["read_resource"] = {
         "name": "read_resource",
@@ -249,7 +264,8 @@ def list_functions(*, env_key: str = "OPENAPI_SPEC_URL") -> str:
         "method": None,
         "operationId": None,
         "original_name": "read_resource",
-        "inputSchema": {"type": "object", "properties": {"uri": {"type": "string", "description": "Resource URI"}}, "required": ["uri"], "additionalProperties": False}
+        "inputSchema": {"type": "object", "properties": {"uri": {"type": "string", "description": "Resource URI"}}, "required": ["uri"], "additionalProperties": False},
+        "annotations": annotations_wire_dict(None, "read_resource", read_only=True),
     }
     functions["list_prompts"] = {
         "name": "list_prompts",
@@ -259,7 +275,8 @@ def list_functions(*, env_key: str = "OPENAPI_SPEC_URL") -> str:
         "method": None,
         "operationId": None,
         "original_name": "list_prompts",
-        "inputSchema": {"type": "object", "properties": {}, "required": [], "additionalProperties": False}
+        "inputSchema": {"type": "object", "properties": {}, "required": [], "additionalProperties": False},
+        "annotations": annotations_wire_dict(None, "list_prompts", read_only=True),
     }
     functions["get_prompt"] = {
         "name": "get_prompt",
@@ -269,7 +286,8 @@ def list_functions(*, env_key: str = "OPENAPI_SPEC_URL") -> str:
         "method": None,
         "operationId": None,
         "original_name": "get_prompt",
-        "inputSchema": {"type": "object", "properties": {"name": {"type": "string", "description": "Prompt name"}}, "required": ["name"], "additionalProperties": False}
+        "inputSchema": {"type": "object", "properties": {"name": {"type": "string", "description": "Prompt name"}}, "required": ["name"], "additionalProperties": False},
+        "annotations": annotations_wire_dict(None, "get_prompt", read_only=True),
     }
     logger.debug(f"Discovered {len(functions)} functions from the OpenAPI specification.")
     if "get_tasks_id" not in functions:
@@ -291,13 +309,24 @@ def list_functions(*, env_key: str = "OPENAPI_SPEC_URL") -> str:
                 },
                 "required": ["user_id"],
                 "additionalProperties": False
-            }
+            },
+            "annotations": annotations_wire_dict(
+                "GET",
+                "get_tasks_id",
+                {"summary": "Get tasks", "operationId": "get_users_tasks"},
+            ),
         }
         logger.debug("Forced registration of get_tasks_id for testing.")
     logger.debug(f"Functions list: {list(functions.values())}")
     return json.dumps(list(functions.values()), indent=2)
 
-@mcp.tool()
+@mcp.tool(
+    title="Call Function",
+    annotations=mcp_types.ToolAnnotations(
+        title="Call Function",
+        destructive_hint=True,
+    ),
+)
 def call_function(*, function_name: str = "", parameters: Optional[Dict] = None, env_key: str = "OPENAPI_SPEC_URL", handle: str = "") -> str:
     """Calls a function derived from the OpenAPI specification.
 

--- a/mcp_openapi_proxy/server_fastmcp.py
+++ b/mcp_openapi_proxy/server_fastmcp.py
@@ -15,11 +15,21 @@ import os
 import json
 import requests
 from typing import Dict, Any, Optional
-from mcp import types
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 from mcp_openapi_proxy.logging_setup import logger
 from mcp_openapi_proxy.openapi import fetch_openapi_spec, build_base_url, handle_auth
 from mcp_openapi_proxy.utils import is_tool_whitelisted, normalize_tool_name, strip_parameters, get_additional_headers, deduplicate_tool_name
+from mcp_openapi_proxy.protocol import (
+    PACKAGE_VERSION,
+    cache_hints,
+    json_response,
+    mcp_host,
+    mcp_path,
+    mcp_port,
+    request_state_security,
+    transport_name,
+    transport_security,
+)
 import sys
 
 # Logger is now configured in logging_setup.py, just use it
@@ -27,7 +37,12 @@ import sys
 
 logger.debug(f"Server CWD: {os.getcwd()}")
 
-mcp = FastMCP("OpenApiProxy-Fast")
+mcp = MCPServer(
+    "OpenApiProxy-Fast",
+    version=PACKAGE_VERSION,
+    cache_hints=cache_hints(),
+    request_state_security=request_state_security(),
+)
 
 spec = None  # Global spec for resources
 
@@ -99,7 +114,10 @@ def list_functions(*, env_key: str = "OPENAPI_SPEC_URL") -> str:
     global spec
     spec = fetch_openapi_spec(spec_url)
     if isinstance(spec, str):
-        spec = json.loads(spec)
+        try:
+            spec = json.loads(spec) if spec.strip() else None
+        except json.JSONDecodeError:
+            spec = None
     if spec is None:
         logger.error("Spec is None after fetch_openapi_spec, using dummy spec fallback")
         spec = {
@@ -191,6 +209,7 @@ def list_functions(*, env_key: str = "OPENAPI_SPEC_URL") -> str:
                     input_schema["required"].append(param_name)
             functions[function_name] = {
                 "name": function_name,
+                "handle": function_name,
                 "description": function_description,
                 "path": path,
                 "method": method.upper(),
@@ -205,6 +224,7 @@ def list_functions(*, env_key: str = "OPENAPI_SPEC_URL") -> str:
             }
     functions["list_resources"] = {
         "name": "list_resources",
+        "handle": "list_resources",
         "description": "List available resources",
         "path": None,
         "method": None,
@@ -214,6 +234,7 @@ def list_functions(*, env_key: str = "OPENAPI_SPEC_URL") -> str:
     }
     functions["read_resource"] = {
         "name": "read_resource",
+        "handle": "read_resource",
         "description": "Read a resource by URI",
         "path": None,
         "method": None,
@@ -223,6 +244,7 @@ def list_functions(*, env_key: str = "OPENAPI_SPEC_URL") -> str:
     }
     functions["list_prompts"] = {
         "name": "list_prompts",
+        "handle": "list_prompts",
         "description": "List available prompts",
         "path": None,
         "method": None,
@@ -232,6 +254,7 @@ def list_functions(*, env_key: str = "OPENAPI_SPEC_URL") -> str:
     }
     functions["get_prompt"] = {
         "name": "get_prompt",
+        "handle": "get_prompt",
         "description": "Get a prompt by name",
         "path": None,
         "method": None,
@@ -243,6 +266,7 @@ def list_functions(*, env_key: str = "OPENAPI_SPEC_URL") -> str:
     if "get_tasks_id" not in functions:
         functions["get_tasks_id"] = {
             "name": "get_tasks_id",
+            "handle": "get_tasks_id",
             "description": "Get tasks",
             "path": "/users/{user_id}/tasks",
             "method": "GET",
@@ -265,8 +289,14 @@ def list_functions(*, env_key: str = "OPENAPI_SPEC_URL") -> str:
     return json.dumps(list(functions.values()), indent=2)
 
 @mcp.tool()
-def call_function(*, function_name: str, parameters: Optional[Dict] = None, env_key: str = "OPENAPI_SPEC_URL") -> str:
-    """Calls a function derived from the OpenAPI specification."""
+def call_function(*, function_name: str = "", parameters: Optional[Dict] = None, env_key: str = "OPENAPI_SPEC_URL", handle: str = "") -> str:
+    """Calls a function derived from the OpenAPI specification.
+
+    ``handle`` is an explicit alias for ``function_name``: the value returned
+    as ``handle`` from list_functions. Either is enough; no prior list_functions
+    call on this process is required (the operation map is rebuilt from the spec).
+    """
+    function_name = function_name or handle
     logger.debug(f"call_function invoked with function_name='{function_name}' and parameters={parameters}")
     logger.debug(f"API_KEY: {os.getenv('API_KEY', '<not set>')[:5] + '...' if os.getenv('API_KEY') else '<not set>'}")
     logger.debug(f"STRIP_PARAM: {os.getenv('STRIP_PARAM', '<not set>')}")
@@ -302,6 +332,11 @@ def call_function(*, function_name: str, parameters: Optional[Dict] = None, env_
         if parameters["name"] != "summarize_spec":
             return json.dumps({"error": "Prompt not found"})
         return json.dumps([{"role": "assistant", "content": {"type": "text", "text": "This OpenAPI spec defines an API’s endpoints, parameters, and responses, making it a blueprint for devs to build and integrate stuff without messing it up."}}])
+    # Rebuild the operation map from the spec when this process never saw
+    # list_functions (fresh instance / round-robin peer). Handles returned by
+    # another instance remain valid because they are just function names.
+    if function_name not in _FUNCTION_OPERATIONS:
+        list_functions(env_key=env_key)
     spec = fetch_openapi_spec(spec_url)
     if spec is None:
         logger.error("Spec is None for call_function")
@@ -454,8 +489,20 @@ def run_simple_server():
     list_functions()
 
     try:
-        logger.debug("Starting MCP server (FastMCP version)...")
-        mcp.run(transport="stdio")
+        selected = transport_name()
+        logger.debug(f"Starting MCP server (MCPServer/simple mode) transport={selected}...")
+        if selected == "streamable-http":
+            mcp.run(
+                transport="streamable-http",
+                host=mcp_host(),
+                port=mcp_port(),
+                streamable_http_path=mcp_path(),
+                json_response=json_response(),
+                stateless_http=True,
+                transport_security=transport_security(),
+            )
+        else:
+            mcp.run(transport="stdio")
     except Exception as e:
         logger.error(f"Unhandled exception in MCP server (FastMCP): {e}", exc_info=True)
         sys.exit(1)

--- a/mcp_openapi_proxy/server_lowlevel.py
+++ b/mcp_openapi_proxy/server_lowlevel.py
@@ -32,6 +32,9 @@ from mcp_openapi_proxy.utils import (
 )
 from mcp_openapi_proxy.protocol import (
     PACKAGE_VERSION,
+    advertised_server_description,
+    advertised_server_name,
+    advertised_server_title,
     cache_hints,
     json_response,
     mcp_host,
@@ -485,10 +488,17 @@ def build_server() -> Server:
     Rebuilt in run_server() so gateway monkeypatches of dispatcher_handler
     are picked up (the v2 Server captures on_* at construction time).
     """
+    name = advertised_server_name()
     kwargs: Dict[str, Any] = {
         "version": PACKAGE_VERSION,
         "cache_hints": cache_hints(),
     }
+    title = advertised_server_title()
+    if title:
+        kwargs["title"] = title
+    description = advertised_server_description()
+    if description:
+        kwargs["description"] = description
     if ENABLE_TOOLS:
         kwargs["on_list_tools"] = list_tools
         kwargs["on_call_tool"] = dispatcher_handler
@@ -498,7 +508,8 @@ def build_server() -> Server:
     if ENABLE_PROMPTS:
         kwargs["on_list_prompts"] = list_prompts
         kwargs["on_get_prompt"] = get_prompt
-    return Server("OpenApiProxy-LowLevel", **kwargs)
+    logger.debug(f"Building MCP server identity name={name!r} title={title!r}")
+    return Server(name, **kwargs)
 
 
 mcp = build_server()

--- a/mcp_openapi_proxy/server_lowlevel.py
+++ b/mcp_openapi_proxy/server_lowlevel.py
@@ -36,6 +36,7 @@ from mcp_openapi_proxy.protocol import (
     advertised_server_name,
     advertised_server_title,
     cache_hints,
+    healthz_route,
     json_response,
     mcp_host,
     mcp_path,
@@ -547,6 +548,22 @@ async def start_server():
     prewarm.cancel()
 
 
+def build_streamable_http_app(*, host: Optional[str] = None, path: Optional[str] = None):
+    """Starlette app for native Streamable HTTP plus process-local GET /healthz.
+
+    /healthz is a sibling custom_starlette_route so it never enters
+    StreamableHTTPSessionManager or the MCP request lock.
+    """
+    return mcp.streamable_http_app(
+        streamable_http_path=path or mcp_path(),
+        json_response=json_response(),
+        stateless_http=True,
+        transport_security=transport_security(),
+        host=host or mcp_host(),
+        custom_starlette_routes=[healthz_route()],
+    )
+
+
 def _run_streamable_http() -> None:
     """Stateless Streamable HTTP: no Mcp-Session-Id, no sticky routing."""
     import uvicorn
@@ -558,13 +575,7 @@ def _run_streamable_http() -> None:
         "Starting Low-Level MCP server (streamable-http, stateless) "
         f"on {host}:{port}{path}"
     )
-    app = mcp.streamable_http_app(
-        streamable_http_path=path,
-        json_response=json_response(),
-        stateless_http=True,
-        transport_security=transport_security(),
-        host=host,
-    )
+    app = build_streamable_http_app(host=host, path=path)
     uvicorn.run(app, host=host, port=port)
 
 

--- a/mcp_openapi_proxy/server_lowlevel.py
+++ b/mcp_openapi_proxy/server_lowlevel.py
@@ -32,6 +32,7 @@ from mcp_openapi_proxy.utils import (
 )
 from mcp_openapi_proxy.protocol import (
     PACKAGE_VERSION,
+    McpRpcLogMiddleware,
     advertised_server_description,
     advertised_server_name,
     advertised_server_title,
@@ -553,8 +554,12 @@ def build_streamable_http_app(*, host: Optional[str] = None, path: Optional[str]
 
     /healthz is a sibling custom_starlette_route so it never enters
     StreamableHTTPSessionManager or the MCP request lock.
+
+    Raw ASGI middleware logs one INFO line per inbound JSON-RPC method
+    (plus tools/call name) before StreamableHTTPSessionManager. Stdio is
+    unchanged.
     """
-    return mcp.streamable_http_app(
+    app = mcp.streamable_http_app(
         streamable_http_path=path or mcp_path(),
         json_response=json_response(),
         stateless_http=True,
@@ -562,6 +567,8 @@ def build_streamable_http_app(*, host: Optional[str] = None, path: Optional[str]
         host=host or mcp_host(),
         custom_starlette_routes=[healthz_route()],
     )
+    app.add_middleware(McpRpcLogMiddleware)
+    return app
 
 
 def _run_streamable_http() -> None:

--- a/mcp_openapi_proxy/server_lowlevel.py
+++ b/mcp_openapi_proxy/server_lowlevel.py
@@ -1,21 +1,8 @@
 """
 Low-Level Server for mcp-openapi-proxy.
 
-This server dynamically registers functions (tools) based on an OpenAPI specification,
-directly utilizing the spec for tool definitions and invocation.
-Configuration is controlled via environment variables:
-- OPENAPI_SPEC_URL: URL to the OpenAPI specification.
-- TOOL_WHITELIST: Comma-separated list of allowed endpoint paths.
-- SERVER_URL_OVERRIDE: Optional override for the base URL from the OpenAPI spec.
-- API_KEY: Generic token for Bearer header.
-- STRIP_PARAM: Param name (e.g., "auth") to remove from parameters.
-- EXTRA_HEADERS: Additional headers in 'Header: Value' format, one per line.
-- CAPABILITIES_TOOLS: Set to "true" to enable tools advertising (default: false).
-- CAPABILITIES_RESOURCES: Set to "true" to enable resources advertising (default: false).
-- CAPABILITIES_PROMPTS: Set to "true" to enable prompts advertising (default: false).
-- ENABLE_TOOLS: Set to "false" to disable tools functionality (default: true).
-- ENABLE_RESOURCES: Set to "false" to disable resources functionality (default: true).
-- ENABLE_PROMPTS: Set to "false" to disable prompts functionality (default: true).
+Dynamically registers tools from an OpenAPI spec. Speaks MCP 2026-07-28
+(stateless, dual-stack with the legacy initialize handshake on stdio).
 """
 
 import os
@@ -25,11 +12,11 @@ import json
 import requests
 from typing import List, Dict, Any, Optional, cast
 import anyio
-from pydantic import AnyUrl
 
-from mcp import types
-from urllib.parse import unquote
-from mcp.server.lowlevel import Server
+from mcp import types as mcp_types
+
+types = mcp_types  # re-export; tests may rebind this name — handlers use mcp_types
+from mcp.server.lowlevel import Server, NotificationOptions
 from mcp.server.models import InitializationOptions
 from mcp.server.stdio import stdio_server
 from mcp_openapi_proxy.utils import (
@@ -43,32 +30,34 @@ from mcp_openapi_proxy.utils import (
     detect_response_type,
     get_additional_headers
 )
+from mcp_openapi_proxy.protocol import (
+    PACKAGE_VERSION,
+    cache_hints,
+    json_response,
+    mcp_host,
+    mcp_path,
+    mcp_port,
+    transport_name,
+    transport_security,
+    unpack_handler_args,
+)
 
 DEBUG = os.getenv("DEBUG", "").lower() in ("true", "1", "yes")
 logger = setup_logging(debug=DEBUG)
 
-tools: List[types.Tool] = []
-# Check capability advertisement envvars (off by default)
+tools: List[mcp_types.Tool] = []
 CAPABILITIES_TOOLS = os.getenv("CAPABILITIES_TOOLS", "false").lower() == "true"
 CAPABILITIES_RESOURCES = os.getenv("CAPABILITIES_RESOURCES", "false").lower() == "true"
 CAPABILITIES_PROMPTS = os.getenv("CAPABILITIES_PROMPTS", "false").lower() == "true"
 
-# Feature enablement (all on by default). Advertising a capability is
-# required for clients to even attempt prompts/list & resources/list;
-# defaulting these OFF made prompts/resources invisible to every client
-# despite being implemented. Set to "false" to opt out.
 ENABLE_TOOLS = os.getenv("ENABLE_TOOLS", "true").lower() == "true"
 ENABLE_RESOURCES = os.getenv("ENABLE_RESOURCES", "true").lower() == "true"
 ENABLE_PROMPTS = os.getenv("ENABLE_PROMPTS", "true").lower() == "true"
 
-# Resource and prompt DEFINITIONS are always present so the feature is
-# deterministically testable. Whether they are EXPOSED to clients is gated
-# separately by ENABLE_RESOURCES / ENABLE_PROMPTS, which control handler
-# registration (run_server) and capability advertisement (build_capabilities).
-resources: List[types.Resource] = [
-    types.Resource(
+resources: List[mcp_types.Resource] = [
+    mcp_types.Resource(
         name="spec_file",
-        uri=AnyUrl("file:///openapi_spec.json"),
+        uri="file:///openapi_spec.json",
         description="The raw OpenAPI specification JSON",
     )
 ]
@@ -76,9 +65,7 @@ resources: List[types.Resource] = [
 
 def _load_additional_resources() -> Dict[str, str]:
     """Parse ADDITIONAL_RESOURCES ("name=/path/file.md,name2=/path2") into
-    {name: path} and register each as a listed resource. Lets a deployment
-    ship use-case documents (naming policies, layout conventions) alongside
-    the spec — see examples/resources/."""
+    {name: path} and register each as a listed resource."""
     mapping: Dict[str, str] = {}
     for entry in os.getenv("ADDITIONAL_RESOURCES", "").split(","):
         entry = entry.strip()
@@ -89,9 +76,9 @@ def _load_additional_resources() -> Dict[str, str]:
             continue
         mapping[name] = path
         resources.append(
-            types.Resource(
+            mcp_types.Resource(
                 name=name,
-                uri=AnyUrl(f"file:///{name}"),
+                uri=f"file:///{name}",
                 description=f"Additional resource served from {os.path.basename(path)}",
             )
         )
@@ -100,36 +87,33 @@ def _load_additional_resources() -> Dict[str, str]:
 
 ADDITIONAL_RESOURCES: Dict[str, str] = _load_additional_resources()
 
-prompts: List[types.Prompt] = [
-    types.Prompt(
+prompts: List[mcp_types.Prompt] = [
+    mcp_types.Prompt(
         name="summarize_spec",
         description="Summarizes the OpenAPI specification",
         arguments=[],
     ),
-    types.Prompt(
+    mcp_types.Prompt(
         name="whimsical_blog",
         description="A whimsical WordPress blog-post starter inspired by this API",
         arguments=[],
     ),
 ]
 
-# Prompt message templates, keyed by prompt name. Kept separate from the
-# types.Prompt metadata, which has no `messages` field — get_prompt() builds
-# the actual PromptMessage list from these.
 PROMPT_TEMPLATES: Dict[str, Any] = {
     "summarize_spec": lambda args: [
-        types.PromptMessage(
+        mcp_types.PromptMessage(
             role="assistant",
-            content=types.TextContent(
+            content=mcp_types.TextContent(
                 type="text",
                 text="This OpenAPI spec defines endpoints, parameters, and responses—a blueprint for developers to integrate effectively.",
             ),
         )
     ],
     "whimsical_blog": lambda args: [
-        types.PromptMessage(
+        mcp_types.PromptMessage(
             role="assistant",
-            content=types.TextContent(
+            content=mcp_types.TextContent(
                 type="text",
                 text=(
                     "Once upon a JSON, in a land of tilde keys and sticky semicolons, a pet AI "
@@ -143,32 +127,25 @@ PROMPT_TEMPLATES: Dict[str, Any] = {
 }
 
 
-def build_capabilities() -> "types.ServerCapabilities":
-    """Advertise a capability whenever its feature is enabled (ENABLE_*).
-
-    A capability object must be present for strict MCP clients (e.g. Gemini,
-    Codex, Qwen) to attempt list_tools/list_resources/list_prompts at all;
-    `listChanged` is a sub-detail controlled by the CAPABILITIES_* envvars.
-    """
-    return types.ServerCapabilities(
-        tools=types.ToolsCapability(listChanged=CAPABILITIES_TOOLS) if ENABLE_TOOLS else None,
-        prompts=types.PromptsCapability(listChanged=CAPABILITIES_PROMPTS) if ENABLE_PROMPTS else None,
-        resources=types.ResourcesCapability(listChanged=CAPABILITIES_RESOURCES) if ENABLE_RESOURCES else None,
+def build_capabilities() -> "mcp_types.ServerCapabilities":
+    """Advertise a capability whenever its feature is enabled (ENABLE_*)."""
+    return mcp_types.ServerCapabilities(
+        tools=mcp_types.ToolsCapability(list_changed=CAPABILITIES_TOOLS) if ENABLE_TOOLS else None,
+        prompts=mcp_types.PromptsCapability(list_changed=CAPABILITIES_PROMPTS) if ENABLE_PROMPTS else None,
+        resources=mcp_types.ResourcesCapability(list_changed=CAPABILITIES_RESOURCES) if ENABLE_RESOURCES else None,
     )
+
 
 openapi_spec_data: Optional[Dict[str, Any]] = None
 
-# Lazy spec loading (issue #28): the MCP handshake must be answered immediately,
-# even when OPENAPI_SPEC_URL is slow to download/parse. Clients with short
-# connect timeouts (observed: Kilocode, Vibe) otherwise hang up mid-handshake,
-# the proxy dies on the closed stream, the client respawns it — a crash loop.
 _spec_load_lock: Optional[asyncio.Lock] = None
 _spec_load_error: Optional[str] = None
 
 
 async def ensure_spec_loaded() -> Optional[Dict[str, Any]]:
     """Fetch and register the OpenAPI spec on first use. Safe to call from any
-    handler; concurrent callers await the same fetch."""
+    handler; concurrent callers await the same fetch. Process-local, not a
+    protocol session — any instance can rebuild this from OPENAPI_SPEC_URL."""
     global openapi_spec_data, _spec_load_lock, _spec_load_error
     if openapi_spec_data is not None or _spec_load_error is not None:
         return openapi_spec_data
@@ -198,41 +175,41 @@ async def ensure_spec_loaded() -> Optional[Dict[str, Any]]:
         return openapi_spec_data
 
 
-mcp = Server("OpenApiProxy-LowLevel")
+async def dispatcher_handler(ctx_or_request: Any, params: Any = None) -> mcp_types.CallToolResult:
+    """Route tools/call to the matching OpenAPI operation.
 
-async def dispatcher_handler(request: types.CallToolRequest) -> types.CallToolResult:
-    """
-    Dispatcher handler that routes CallToolRequest to the appropriate function (tool).
+    Signature is MCP SDK v2 ``(ctx, params)``. A single request-like object
+    (with ``.params``) is still accepted for tests and gateway wrappers.
     """
     global openapi_spec_data
+    _, params = unpack_handler_args(ctx_or_request, params)
     try:
         await ensure_spec_loaded()
-        function_name = request.params.name
+        function_name = params.name
         logger.debug(f"Dispatcher received CallToolRequest for function: {function_name}")
         logger.debug(f"API_KEY: {os.getenv('API_KEY', '<not set>')[:5] + '...' if os.getenv('API_KEY') else '<not set>'}")
         logger.debug(f"STRIP_PARAM: {os.getenv('STRIP_PARAM', '<not set>')}")
         tool = next((t for t in tools if t.name == function_name), None)
         if not tool:
             logger.error(f"Unknown function requested: {function_name}")
-            return types.CallToolResult(
-                content=[types.TextContent(type="text", text="Unknown function requested")],
-                isError=False,
+            return mcp_types.CallToolResult(
+                content=[mcp_types.TextContent(type="text", text="Unknown function requested")],
+                is_error=False,
             )
-        arguments = request.params.arguments or {}
+        arguments = params.arguments or {}
         logger.debug(f"Raw arguments before processing: {arguments}")
 
         if openapi_spec_data is None:
-            return types.CallToolResult(
-                content=[types.TextContent(type="text", text="OpenAPI spec not loaded")],
-                isError=True,
+            return mcp_types.CallToolResult(
+                content=[mcp_types.TextContent(type="text", text="OpenAPI spec not loaded")],
+                is_error=True,
             )
-        # Since we've checked openapi_spec_data is not None, cast it to Dict.
         operation_details = lookup_operation_details(function_name, cast(Dict, openapi_spec_data))
         if not operation_details:
             logger.error(f"Could not find OpenAPI operation for function: {function_name}")
-            return types.CallToolResult(
-                content=[types.TextContent(type="text", text=f"Could not find OpenAPI operation for function: {function_name}")],
-                isError=False,
+            return mcp_types.CallToolResult(
+                content=[mcp_types.TextContent(type="text", text=f"Could not find OpenAPI operation for function: {function_name}")],
+                is_error=False,
             )
 
         operation = operation_details["operation"]
@@ -249,12 +226,6 @@ async def dispatcher_handler(request: types.CallToolRequest) -> types.CallToolRe
         try:
             path = path.format(**parameters)
             logger.debug(f"Substituted path using format(): {path}")
-            # Path placeholders are now substituted into the URL, so drop them from
-            # `parameters` for ALL methods. Previously this ran only for GET, so on
-            # POST/PUT/PATCH/DELETE the path params leaked into request_body and
-            # strict APIs rejected the unexpected fields -- e.g. Home Assistant
-            # POST /api/services/{domain}/{service} returned HTTP 400 because the
-            # body carried domain/service.
             placeholder_keys = [
                 seg.strip("{}")
                 for seg in operation_details["original_path"].split("/")
@@ -264,17 +235,17 @@ async def dispatcher_handler(request: types.CallToolRequest) -> types.CallToolRe
                 parameters.pop(key, None)
         except KeyError as e:
             logger.error(f"Missing parameter for substitution: {e}")
-            return types.CallToolResult(
-                content=[types.TextContent(type="text", text=f"Missing parameter: {e}")],
-                isError=False,
+            return mcp_types.CallToolResult(
+                content=[mcp_types.TextContent(type="text", text=f"Missing parameter: {e}")],
+                is_error=False,
             )
 
         base_url = build_base_url(cast(Dict, openapi_spec_data))
         if not base_url:
             logger.critical("Failed to construct base URL from spec or SERVER_URL_OVERRIDE.")
-            return types.CallToolResult(
-                content=[types.TextContent(type="text", text="No base URL defined in spec or SERVER_URL_OVERRIDE")],
-                isError=False,
+            return mcp_types.CallToolResult(
+                content=[mcp_types.TextContent(type="text", text="No base URL defined in spec or SERVER_URL_OVERRIDE")],
+                is_error=False,
             )
 
         api_url = f"{base_url.rstrip('/')}/{path.lstrip('/')}"
@@ -296,9 +267,9 @@ async def dispatcher_handler(request: types.CallToolRequest) -> types.CallToolRe
                 ]
                 if missing_required:
                     logger.error(f"Missing required path parameters: {missing_required}")
-                    return types.CallToolResult(
-                        content=[types.TextContent(type="text", text=f"Missing required path parameters: {missing_required}")],
-                        isError=False,
+                    return mcp_types.CallToolResult(
+                        content=[mcp_types.TextContent(type="text", text=f"Missing required path parameters: {missing_required}")],
+                        is_error=False,
                     )
             if method == "GET":
                 request_params = parameters
@@ -327,54 +298,50 @@ async def dispatcher_handler(request: types.CallToolRequest) -> types.CallToolRe
             response_text = (response.text or "No response body").strip()
             content, log_message = detect_response_type(response_text)
             logger.debug(log_message)
-            # Expect content to be of a type that can be included as is.
             final_content = [content]
         except requests.exceptions.RequestException as e:
             logger.error(f"API request failed: {e}")
-            return types.CallToolResult(
-                content=[types.TextContent(type="text", text=str(e))],
-                isError=False,
+            return mcp_types.CallToolResult(
+                content=[mcp_types.TextContent(type="text", text=str(e))],
+                is_error=False,
             )
         logger.debug(f"Response content type: {content.type}")
         logger.debug(f"Response sent to client: {content.text}")
-        return types.CallToolResult(content=final_content, isError=False)
+        return mcp_types.CallToolResult(content=final_content, is_error=False)
     except Exception as e:
         logger.error(f"Unhandled exception in dispatcher_handler: {e}", exc_info=True)
-        return types.CallToolResult(
-            content=[types.TextContent(type="text", text=f"Internal error: {str(e)}")],
-            isError=False,
+        return mcp_types.CallToolResult(
+            content=[mcp_types.TextContent(type="text", text=f"Internal error: {str(e)}")],
+            is_error=True,
         )
 
 
-async def list_tools(request: types.ListToolsRequest) -> types.ListToolsResult:
+async def list_tools(ctx_or_request: Any = None, params: Any = None) -> mcp_types.ListToolsResult:
     logger.debug("Handling list_tools request - start")
     await ensure_spec_loaded()
     logger.debug(f"Tools list length: {len(tools)}")
-    return types.ListToolsResult(tools=tools)
+    return mcp_types.ListToolsResult(tools=tools)
 
-async def list_resources(request: types.ListResourcesRequest) -> types.ListResourcesResult:
-    """List the spec_file resource plus any ADDITIONAL_RESOURCES entries.
 
-    The module-level `resources` list is always seeded with spec_file; the
-    guard below only matters if a caller mutated it at runtime.
-    """
+async def list_resources(ctx_or_request: Any = None, params: Any = None) -> mcp_types.ListResourcesResult:
     logger.debug(f"Handling list_resources request ({len(resources)} resources)")
     if not resources:
         logger.debug("Resources empty; repopulating default resource")
         resources.append(
-            types.Resource(
+            mcp_types.Resource(
                 name="spec_file",
-                uri=AnyUrl("file:///openapi_spec.json"),
+                uri="file:///openapi_spec.json",
                 description="The raw OpenAPI specification JSON",
             )
         )
-    return types.ListResourcesResult(resources=resources)
+    return mcp_types.ListResourcesResult(resources=resources)
 
 
-async def read_resource(request: types.ReadResourceRequest) -> types.ReadResourceResult:
-    logger.debug(f"START read_resource for URI: {request.params.uri}")
+async def read_resource(ctx_or_request: Any, params: Any = None) -> mcp_types.ReadResourceResult:
+    _, params = unpack_handler_args(ctx_or_request, params)
+    uri_str = str(params.uri)
+    logger.debug(f"START read_resource for URI: {uri_str}")
     try:
-        uri_str = str(request.params.uri)
         for name, path in ADDITIONAL_RESOURCES.items():
             if uri_str == f"file:///{name}":
                 try:
@@ -383,10 +350,10 @@ async def read_resource(request: types.ReadResourceRequest) -> types.ReadResourc
                 except OSError as exc:
                     text = f"Resource '{name}' unavailable: {exc}"
                 mime = "text/markdown" if path.endswith((".md", ".markdown")) else "text/plain"
-                return types.ReadResourceResult(
+                return mcp_types.ReadResourceResult(
                     contents=[
-                        types.TextResourceContents(
-                            uri=request.params.uri, text=text, mimeType=mime
+                        mcp_types.TextResourceContents(
+                            uri=uri_str, text=text, mime_type=mime
                         )
                     ]
                 )
@@ -394,10 +361,10 @@ async def read_resource(request: types.ReadResourceRequest) -> types.ReadResourc
         logger.debug(f"Got OPENAPI_SPEC_URL: {openapi_url}")
         if not openapi_url:
             logger.error("OPENAPI_SPEC_URL not set")
-            return types.ReadResourceResult(
+            return mcp_types.ReadResourceResult(
                 contents=[
-                    types.TextResourceContents(
-                        uri=request.params.uri,
+                    mcp_types.TextResourceContents(
+                        uri=uri_str,
                         text="Spec unavailable: OPENAPI_SPEC_URL not set"
                     )
                 ]
@@ -407,10 +374,10 @@ async def read_resource(request: types.ReadResourceRequest) -> types.ReadResourc
         logger.debug(f"Spec fetched: {spec_data is not None}")
         if not spec_data:
             logger.error("Failed to fetch OpenAPI spec")
-            return types.ReadResourceResult(
+            return mcp_types.ReadResourceResult(
                 contents=[
-                    types.TextResourceContents(
-                        uri=request.params.uri,
+                    mcp_types.TextResourceContents(
+                        uri=uri_str,
                         text="Spec data unavailable after fetch attempt"
                     )
                 ]
@@ -418,71 +385,78 @@ async def read_resource(request: types.ReadResourceRequest) -> types.ReadResourc
         logger.debug("Dumping spec to JSON...")
         spec_json = json.dumps(spec_data, indent=2, default=str)
         logger.debug(f"Forcing spec JSON return: {spec_json[:50]}...")
-        return types.ReadResourceResult(
+        return mcp_types.ReadResourceResult(
             contents=[
-                types.TextResourceContents(
+                mcp_types.TextResourceContents(
                     uri="file:///openapi_spec.json",
                     text=spec_json,
-                    mimeType="application/json"
+                    mime_type="application/json"
                 )
             ]
         )
     except Exception as e:
         logger.error(f"Error forcing resource: {e}", exc_info=True)
-        return types.ReadResourceResult(
+        return mcp_types.ReadResourceResult(
             contents=[
-                types.TextResourceContents(
-                    uri=request.params.uri,
+                mcp_types.TextResourceContents(
+                    uri=uri_str,
                     text=f"Resource error: {str(e)}"
                 )
             ]
         )
 
 
-async def list_prompts(request: types.ListPromptsRequest) -> types.ListPromptsResult:
+async def list_prompts(ctx_or_request: Any = None, params: Any = None) -> mcp_types.ListPromptsResult:
     logger.debug("Handling list_prompts request")
     logger.debug(f"Prompts list length: {len(prompts)}")
-    return types.ListPromptsResult(prompts=prompts)
+    return mcp_types.ListPromptsResult(prompts=prompts)
 
 
-async def get_prompt(request: types.GetPromptRequest) -> types.GetPromptResult:
-    logger.debug(f"Handling get_prompt request for {request.params.name}")
-    template = PROMPT_TEMPLATES.get(request.params.name)
+async def get_prompt(ctx_or_request: Any, params: Any = None) -> mcp_types.GetPromptResult:
+    _, params = unpack_handler_args(ctx_or_request, params)
+    name = params.name
+    logger.debug(f"Handling get_prompt request for {name}")
+    template = PROMPT_TEMPLATES.get(name)
     if template is None:
-        logger.error(f"Prompt '{request.params.name}' not found")
-        return types.GetPromptResult(
+        logger.error(f"Prompt '{name}' not found")
+        return mcp_types.GetPromptResult(
             description="Prompt not found",
             messages=[
-                types.PromptMessage(
+                mcp_types.PromptMessage(
                     role="assistant",
-                    content=types.TextContent(type="text", text=f"Prompt '{request.params.name}' not found"),
+                    content=mcp_types.TextContent(type="text", text=f"Prompt '{name}' not found"),
                 )
             ],
         )
     try:
-        messages = template(request.params.arguments or {})
+        messages = template(getattr(params, "arguments", None) or {})
         logger.debug(f"Generated messages: {messages}")
-        return types.GetPromptResult(messages=messages)
+        return mcp_types.GetPromptResult(messages=messages)
     except Exception as e:
         logger.error(f"Error generating prompt: {e}", exc_info=True)
-        return types.GetPromptResult(
+        return mcp_types.GetPromptResult(
             messages=[
-                types.PromptMessage(
+                mcp_types.PromptMessage(
                     role="assistant",
-                    content=types.TextContent(type="text", text=f"Prompt error: {str(e)}"),
+                    content=mcp_types.TextContent(type="text", text=f"Prompt error: {str(e)}"),
                 )
             ],
         )
 
 
 def lookup_operation_details(function_name: str, spec: Dict[str, Any]) -> Optional[Dict[str, Any]]:
-    # Resolve names recorded at registration time first: names deduplicated
-    # after TOOL_NAME_MAX_LENGTH truncation (issue #11) cannot be regenerated
-    # from the spec alone.
     from mcp_openapi_proxy.openapi import _REGISTERED_OPERATIONS
     registered = _REGISTERED_OPERATIONS.get(function_name)
     if registered:
         return dict(registered)
+    # Stateless rebuild: a fresh instance (or a round-robin peer) that never
+    # saw tools/list can still resolve a name by registering from the spec.
+    if spec and not _REGISTERED_OPERATIONS:
+        from mcp_openapi_proxy.handlers import register_functions
+        register_functions(spec)
+        registered = _REGISTERED_OPERATIONS.get(function_name)
+        if registered:
+            return dict(registered)
     if not spec or 'paths' not in spec:
         return None
     for path, path_item in spec['paths'].items():
@@ -505,31 +479,56 @@ def _is_closed_stream_error(exc: BaseException) -> bool:
     return False
 
 
+def build_server() -> Server:
+    """Construct a low-level Server from the current handler callables.
+
+    Rebuilt in run_server() so gateway monkeypatches of dispatcher_handler
+    are picked up (the v2 Server captures on_* at construction time).
+    """
+    kwargs: Dict[str, Any] = {
+        "version": PACKAGE_VERSION,
+        "cache_hints": cache_hints(),
+    }
+    if ENABLE_TOOLS:
+        kwargs["on_list_tools"] = list_tools
+        kwargs["on_call_tool"] = dispatcher_handler
+    if ENABLE_RESOURCES:
+        kwargs["on_list_resources"] = list_resources
+        kwargs["on_read_resource"] = read_resource
+    if ENABLE_PROMPTS:
+        kwargs["on_list_prompts"] = list_prompts
+        kwargs["on_get_prompt"] = get_prompt
+    return Server("OpenApiProxy-LowLevel", **kwargs)
+
+
+mcp = build_server()
+
+
+def _initialization_options() -> InitializationOptions:
+    return mcp.create_initialization_options(
+        notification_options=NotificationOptions(
+            tools_changed=CAPABILITIES_TOOLS,
+            prompts_changed=CAPABILITIES_PROMPTS,
+            resources_changed=CAPABILITIES_RESOURCES,
+        )
+    )
+
+
 async def start_server():
-    logger.debug("Starting Low-Level MCP server...")
-    # Pre-warm the spec in the background: the handshake is served immediately
-    # while the (possibly slow) spec download proceeds (issue #28).
+    logger.debug("Starting Low-Level MCP server (stdio, dual-stack)...")
     prewarm = asyncio.create_task(ensure_spec_loaded())
     async with stdio_server() as (read_stream, write_stream):
         while True:
             try:
-                capabilities = build_capabilities()
                 await mcp.run(
                     read_stream,
                     write_stream,
-                    initialization_options=InitializationOptions(
-                        server_name="AnyOpenAPIMCP-LowLevel",
-                        server_version="0.1.0",
-                        capabilities=capabilities,
-                    ),
+                    initialization_options=_initialization_options(),
                 )
                 logger.debug("MCP session ended normally; exiting.")
                 break
             except BaseException as e:
                 if _is_closed_stream_error(e):
-                    # Client disconnected (e.g. short connect timeout while the
-                    # spec was still loading). Exit cleanly instead of spinning
-                    # on a dead stream — the client respawns us if it wants to.
                     logger.warning("Client closed the stream; shutting down cleanly.")
                     break
                 logger.error(f"MCP run crashed: {e}", exc_info=True)
@@ -537,24 +536,40 @@ async def start_server():
     prewarm.cancel()
 
 
+def _run_streamable_http() -> None:
+    """Stateless Streamable HTTP: no Mcp-Session-Id, no sticky routing."""
+    import uvicorn
+
+    host = mcp_host()
+    port = mcp_port()
+    path = mcp_path()
+    logger.debug(
+        "Starting Low-Level MCP server (streamable-http, stateless) "
+        f"on {host}:{port}{path}"
+    )
+    app = mcp.streamable_http_app(
+        streamable_http_path=path,
+        json_response=json_response(),
+        stateless_http=True,
+        transport_security=transport_security(),
+        host=host,
+    )
+    uvicorn.run(app, host=host, port=port)
+
+
 def run_server():
+    global mcp
     try:
         if not os.getenv('OPENAPI_SPEC_URL'):
             logger.critical("OPENAPI_SPEC_URL environment variable is required but not set.")
             sys.exit(1)
-        # Spec fetch + tool registration are lazy (ensure_spec_loaded) so the
-        # MCP handshake is never blocked by a slow spec download (issue #28).
-        if ENABLE_TOOLS:
-            mcp.request_handlers[types.ListToolsRequest] = list_tools
-            mcp.request_handlers[types.CallToolRequest] = dispatcher_handler
-        if ENABLE_RESOURCES:
-            mcp.request_handlers[types.ListResourcesRequest] = list_resources
-            mcp.request_handlers[types.ReadResourceRequest] = read_resource
-        if ENABLE_PROMPTS:
-            mcp.request_handlers[types.ListPromptsRequest] = list_prompts
-            mcp.request_handlers[types.GetPromptRequest] = get_prompt
+        # Rebuild so monkeypatches (gateway query-auth) bind into on_call_tool.
+        mcp = build_server()
         logger.debug("Handlers registered based on capabilities and enablement envvars.")
-        asyncio.run(start_server())
+        if transport_name() == "streamable-http":
+            _run_streamable_http()
+        else:
+            asyncio.run(start_server())
     except KeyboardInterrupt:
         logger.debug("MCP server shutdown initiated by user.")
     except Exception as e:

--- a/mcp_openapi_proxy/types.py
+++ b/mcp_openapi_proxy/types.py
@@ -1,53 +1,64 @@
-from pydantic import BaseModel, AnyUrl
+from pydantic import BaseModel
 from typing import List, Optional
+
 
 class TextContent(BaseModel):
     type: str
     text: str
     uri: Optional[str] = None
 
-# Define resource contents as a direct subtype.
-# Removed 'type' field to satisfy Pylance, though ValidationError suggests it's needed.
+
 class TextResourceContents(BaseModel):
     text: str
-    uri: AnyUrl # Expects AnyUrl, not str
+    uri: str
+    mime_type: Optional[str] = None
+
 
 class CallToolResult(BaseModel):
-    content: List[TextContent] # Expects TextContent, not TextResourceContents directly
-    isError: bool = False
+    content: List[TextContent]
+    is_error: bool = False
+
 
 class ServerResult(BaseModel):
     root: CallToolResult
 
+
 class Tool(BaseModel):
     name: str
     description: str
-    inputSchema: dict
+    input_schema: dict
+
 
 class Prompt(BaseModel):
     name: str
     description: str
     arguments: List = []
 
-# PromptMessage represents one message in a prompt conversation.
+
 class PromptMessage(BaseModel):
     role: str
     content: TextContent
 
+
 class GetPromptResult(BaseModel):
     messages: List[PromptMessage]
+
 
 class ListPromptsResult(BaseModel):
     prompts: List[Prompt]
 
+
 class ToolsCapability(BaseModel):
-    listChanged: bool
+    list_changed: bool
+
 
 class PromptsCapability(BaseModel):
-    listChanged: bool
+    list_changed: bool
+
 
 class ResourcesCapability(BaseModel):
-    listChanged: bool
+    list_changed: bool
+
 
 class ServerCapabilities(BaseModel):
     tools: Optional[ToolsCapability] = None

--- a/mcp_openapi_proxy/utils.py
+++ b/mcp_openapi_proxy/utils.py
@@ -363,8 +363,15 @@ def handle_auth(operation: Dict) -> Dict[str, str]:
             # Potentially add basic auth implementation here if needed
         elif auth_type == "api-key":
             key_name = os.getenv("API_AUTH_HEADER", "Authorization")
-            headers[key_name] = api_key
-            logger.debug(f"Using API_KEY as API-Key in header '{key_name}'.") # Avoid logging key prefix
+            if auth_type_raw != auth_type:
+                # User typed a capitalized scheme (e.g. API_AUTH_TYPE=Api-Key):
+                # send "Authorization: Api-Key <key>" preserving the scheme.
+                # Lowercase `api-key` keeps the raw-key behavior (x-apikey style).
+                headers[key_name] = f"{auth_type_raw} {api_key}"
+                logger.debug(f"Using API_KEY with scheme '{auth_type_raw}' in header '{key_name}'.")
+            else:
+                headers[key_name] = api_key
+                logger.debug(f"Using API_KEY as API-Key in header '{key_name}'.") # Avoid logging key prefix
         elif auth_type:
             # Custom scheme prefix, e.g. API_AUTH_TYPE=Token for NetBox -> "Authorization: Token <key>"
             headers["Authorization"] = f"{auth_type_raw} {api_key}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,24 +5,23 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "mcp-openapi-proxy"
 requires-python = ">=3.10"
-version = "0.3.4"
+version = "0.4.0"
 description = "MCP server for exposing OpenAPI specifications as MCP tools."
 readme = "README.md"
 authors = [
   { name = "Matthew Hand", email = "11550632+matthewhand@users.noreply.github.com" }
 ]
 dependencies = [
-  # mcp 2.x is a breaking rewrite (FastMCP renamed to MCPServer, Resource.uri type
-  # change, etc.) that crashes both server modes at import. Pin to 1.x; see
-  # tests/unit/test_mcp_version_pin.py before relaxing this bound.
-  "mcp[cli]>=1.2.0,<2",
+  # mcp 2.x speaks MCP 2026-07-28 (stateless dual-stack). See docs/MIGRATION-0.4.md.
+  "mcp[cli]>=2.0.0,<3",
   "python-dotenv>=1.0.1",
   "requests>=2.25.0",
   "fastapi>=0.100.0", # For OpenAPI parsing utils if used later, and data validation
-  "pydantic>=2.0",
+  "pydantic>=2.12",
   "prance>=23.6.21.0",
   "openapi-spec-validator>=0.7.1",
   "jmespath>=1.0.1",
+  "uvicorn>=0.32.0",
 ]
 
 [project.scripts]
@@ -32,7 +31,9 @@ mcp-openapi-proxy = "mcp_openapi_proxy:main"  # Correct entry pointing to __init
 dev = [
     "pytest>=8.3.4",
     "pytest-asyncio>=0.21.0",
-    "pytest-cov>=4.1.0"
+    "pytest-cov>=4.1.0",
+    "httpx>=0.27.0",
+    "packaging>=24.0",
 ]
 
 [tool.pytest.ini_options]

--- a/tests/integration/test_client_discovery.py
+++ b/tests/integration/test_client_discovery.py
@@ -260,3 +260,41 @@ def test_simple_mode_serves_resources(simple_server):
     rd = client.request("resources/read", {"uri": "file:///openapi_spec.json"})
     contents = rd.get("result", {}).get("contents", [])
     assert contents and contents[0].get("text"), f"resources/read returned no content: {rd}"
+
+
+def _modern_params(extra=None):
+    params = extra or {}
+    params["_meta"] = {
+        "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+        "io.modelcontextprotocol/clientInfo": {"name": "discovery-test", "version": "0"},
+        "io.modelcontextprotocol/clientCapabilities": {},
+    }
+    return params
+
+
+def test_tools_list_without_initialize_handshake(server):
+    """2026-07-28: tools/list must work with no prior initialize."""
+    client = StdioClient(server)
+    # Optional probe; either discover or a direct list must succeed.
+    discover = None
+    try:
+        discover = client.request("server/discover", _modern_params(), timeout=10.0)
+    except Exception:
+        discover = None
+    tools = client.request("tools/list", _modern_params(), timeout=20.0)
+    assert "result" in tools, (
+        f"tools/list without handshake failed: {tools} (discover={discover})"
+    )
+    assert tools["result"].get("tools"), f"no tools: {tools}"
+
+
+def test_server_discover_advertises_modern_version(server):
+    client = StdioClient(server)
+    resp = client.request("server/discover", _modern_params(), timeout=10.0)
+    if "error" in resp and resp["error"].get("code") == -32601:
+        pytest.skip("server/discover not wired on this transport yet")
+    assert "result" in resp, f"server/discover failed: {resp}"
+    result = resp["result"]
+    versions = result.get("protocolVersions") or result.get("supportedProtocolVersions") or []
+    blob = json.dumps(result)
+    assert "2026-07-28" in blob or "2026-07-28" in versions, blob

--- a/tests/integration/test_mcp2_http_roundrobin.py
+++ b/tests/integration/test_mcp2_http_roundrobin.py
@@ -1,0 +1,162 @@
+"""Round-robin / multi-instance tests for stateless Streamable HTTP.
+
+Two independent server processes, no sticky routing, no Mcp-Session-Id.
+A tools/list on instance A must be usable as a tools/call on instance B.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+
+import pytest
+
+from mcp_openapi_proxy.protocol import (
+    HEADER_SESSION_ID,
+    modern_headers,
+    modern_request_meta,
+)
+
+SPEC = {
+    "openapi": "3.0.0",
+    "info": {"title": "rr-test", "version": "1.0.0"},
+    "servers": [{"url": "http://example.test"}],
+    "paths": {
+        "/ping": {
+            "get": {
+                "summary": "Ping",
+                "operationId": "ping",
+                "responses": {"200": {"description": "ok"}},
+            }
+        }
+    },
+}
+
+
+def _free_port() -> int:
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    return port
+
+
+def _rpc(url: str, method: str, params=None, name=None, rpc_id=1, timeout=8.0):
+    body = {
+        "jsonrpc": "2.0",
+        "id": rpc_id,
+        "method": method,
+        "params": {**(params or {}), "_meta": modern_request_meta()},
+    }
+    headers = modern_headers(method, name=name)
+    headers.setdefault("Accept", "application/json, text/event-stream")
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(body).encode("utf-8"),
+        headers=headers,
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        raw = resp.read().decode("utf-8")
+        header_map = {k.lower(): v for k, v in resp.headers.items()}
+        return resp.status, json.loads(raw), header_map
+
+
+def _wait_ready(url: str, timeout=20.0):
+    deadline = time.monotonic() + timeout
+    last = None
+    while time.monotonic() < deadline:
+        try:
+            status, payload, _ = _rpc(url, "tools/list", rpc_id=0)
+            if status == 200 and "result" in payload:
+                return payload
+        except Exception as exc:
+            last = exc
+            time.sleep(0.2)
+    raise TimeoutError(f"server at {url} not ready: {last}")
+
+
+@pytest.fixture
+def two_http_servers(tmp_path):
+    spec_path = tmp_path / "spec.json"
+    spec_path.write_text(json.dumps(SPEC))
+    procs = []
+    urls = []
+    repo = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+    try:
+        for _ in range(2):
+            port = _free_port()
+            env = dict(os.environ)
+            env.update({
+                "OPENAPI_SPEC_URL": spec_path.as_uri(),
+                "MCP_TRANSPORT": "streamable-http",
+                "MCP_HOST": "127.0.0.1",
+                "MCP_PORT": str(port),
+                "MCP_PATH": "/mcp",
+                "MCP_JSON_RESPONSE": "true",
+                "MCP_ALLOWED_HOSTS": "*",
+                "DEBUG": "false",
+                "PYTHONPATH": repo + os.pathsep + env.get("PYTHONPATH", ""),
+            })
+            proc = subprocess.Popen(
+                [sys.executable, "-c", "from mcp_openapi_proxy import main; main()"],
+                env=env,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+            )
+            procs.append(proc)
+            urls.append(f"http://127.0.0.1:{port}/mcp")
+        for url in urls:
+            _wait_ready(url)
+        yield urls
+    finally:
+        for proc in procs:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except Exception:
+                proc.kill()
+
+
+def test_round_robin_list_then_call(two_http_servers, monkeypatch):
+    """Instance A lists tools; instance B calls one. No session header."""
+    url_a, url_b = two_http_servers
+    status, listed, headers_a = _rpc(url_a, "tools/list", rpc_id=1)
+    assert status == 200, listed
+    assert HEADER_SESSION_ID.lower() not in headers_a
+    tools = listed["result"]["tools"]
+    assert tools
+    name = tools[0]["name"]
+
+    # Alternate: even retries go to B, the instance that never saw the list.
+    status, called, headers_b = _rpc(
+        url_b,
+        "tools/call",
+        params={"name": name, "arguments": {}},
+        name=name,
+        rpc_id=2,
+    )
+    assert status == 200, called
+    assert HEADER_SESSION_ID.lower() not in headers_b
+    # Upstream example.test is not up; a protocol-level result or tool error
+    # is success. A session/handshake error is not.
+    err = called.get("error")
+    if err:
+        msg = json.dumps(err).lower()
+        assert "initialize" not in msg
+        assert "session" not in msg
+
+
+def test_round_robin_retries_same_id(two_http_servers):
+    url_a, url_b = two_http_servers
+    payload_id = 99
+    _, first, _ = _rpc(url_a, "tools/list", rpc_id=payload_id)
+    _, second, _ = _rpc(url_b, "tools/list", rpc_id=payload_id)
+    assert "result" in first and "result" in second
+    assert first["result"]["tools"] and second["result"]["tools"]

--- a/tests/unit/test_additional_resources.py
+++ b/tests/unit/test_additional_resources.py
@@ -22,7 +22,8 @@ if uri:
     )
     result = asyncio.new_event_loop().run_until_complete(srv.read_resource(req))
     out["text"] = result.contents[0].text
-    out["mime"] = getattr(result.contents[0], "mimeType", None)
+    content = result.contents[0]
+    out["mime"] = getattr(content, "mime_type", None) or getattr(content, "mimeType", None)
 print(json.dumps(out))
 """
 

--- a/tests/unit/test_advertised_server_name.py
+++ b/tests/unit/test_advertised_server_name.py
@@ -1,0 +1,52 @@
+import os
+
+from mcp_openapi_proxy.protocol import advertised_server_name, advertised_server_title
+
+
+def test_explicit_mcp_server_name(monkeypatch):
+    monkeypatch.setenv("MCP_SERVER_NAME", "gpt-terminal-plus")
+    monkeypatch.setenv("OPENAPI_SPEC_URL", "https://example.com/openapi.json")
+    assert advertised_server_name() == "gpt-terminal-plus"
+
+
+def test_openapi_server_name_alias(monkeypatch):
+    monkeypatch.delenv("MCP_SERVER_NAME", raising=False)
+    monkeypatch.setenv("OPENAPI_SERVER_NAME", "netbox")
+    assert advertised_server_name() == "netbox"
+
+
+def test_file_url_uses_stem(monkeypatch):
+    monkeypatch.delenv("MCP_SERVER_NAME", raising=False)
+    monkeypatch.delenv("OPENAPI_SERVER_NAME", raising=False)
+    monkeypatch.setenv("OPENAPI_SPEC_URL", "file:///home/chatgpt/mcp-gateway/specs/wordpress-dev.json")
+    assert advertised_server_name() == "wordpress-dev"
+
+
+def test_http_url_uses_host(monkeypatch):
+    monkeypatch.delenv("MCP_SERVER_NAME", raising=False)
+    monkeypatch.delenv("OPENAPI_SERVER_NAME", raising=False)
+    monkeypatch.setenv("OPENAPI_SPEC_URL", "https://glama.ai/api/mcp/openapi.json")
+    assert advertised_server_name() == "glama.ai"
+
+
+def test_fallback_without_spec(monkeypatch):
+    monkeypatch.delenv("MCP_SERVER_NAME", raising=False)
+    monkeypatch.delenv("OPENAPI_SERVER_NAME", raising=False)
+    monkeypatch.delenv("OPENAPI_SPEC_URL", raising=False)
+    assert advertised_server_name() == "openapi-proxy"
+
+
+def test_title_optional(monkeypatch):
+    monkeypatch.delenv("MCP_SERVER_TITLE", raising=False)
+    assert advertised_server_title() is None
+    monkeypatch.setenv("MCP_SERVER_TITLE", "GPT Terminal Plus")
+    assert advertised_server_title() == "GPT Terminal Plus"
+
+
+def test_build_server_uses_env_name(monkeypatch):
+    monkeypatch.setenv("MCP_SERVER_NAME", "apisguru")
+    monkeypatch.setenv("OPENAPI_SPEC_URL", "http://dummy.com")
+    from mcp_openapi_proxy.server_lowlevel import build_server
+
+    server = build_server()
+    assert server.name == "apisguru"

--- a/tests/unit/test_capabilities.py
+++ b/tests/unit/test_capabilities.py
@@ -1,72 +1,22 @@
-import os
-import asyncio
 import pytest
-# Import necessary components directly for the test
-from mcp_openapi_proxy.server_lowlevel import mcp, InitializationOptions, types, CAPABILITIES_TOOLS, CAPABILITIES_PROMPTS, CAPABILITIES_RESOURCES
-from unittest.mock import patch, AsyncMock
+
 
 @pytest.fixture
 def mock_env(monkeypatch):
     monkeypatch.delenv("OPENAPI_SPEC_URL", raising=False)
     monkeypatch.setenv("OPENAPI_SPEC_URL", "http://dummy.com")
 
-def dummy_stdio_server():
-    class DummyAsyncCM:
-        async def __aenter__(self):
-            return (AsyncMock(), AsyncMock())
-        async def __aexit__(self, exc_type, exc_val, exc_tb):
-            pass
-    return DummyAsyncCM()
 
-@pytest.mark.asyncio
-async def test_capabilities_passed_to_mcp_run(mock_env):
-    """Verify that the correct capabilities are passed to mcp.run based on defaults."""
-    # Define expected capabilities based on default env vars in server_lowlevel
-    # Defaults are CAPABILITIES_TOOLS=true, others=false
-    expected_capabilities = types.ServerCapabilities(
-        tools=types.ToolsCapability(listChanged=True) if CAPABILITIES_TOOLS else None,
-        prompts=types.PromptsCapability(listChanged=True) if CAPABILITIES_PROMPTS else None,
-        resources=types.ResourcesCapability(listChanged=True) if CAPABILITIES_RESOURCES else None
-    )
-    expected_init_options = InitializationOptions(
-        server_name="AnyOpenAPIMCP-LowLevel",
-        server_version="0.1.0",
-        capabilities=expected_capabilities,
+def test_initialization_options_advertise_enabled_features(mock_env):
+    """create_initialization_options reflects ENABLE_* / CAPABILITIES_* flags."""
+    from mcp_openapi_proxy.server_lowlevel import (
+        _initialization_options,
+        PACKAGE_VERSION,
+        build_capabilities,
     )
 
-    # Mock the stdio streams and the mcp.run call
-    mock_read_stream = AsyncMock()
-    mock_write_stream = AsyncMock()
-    with patch('mcp_openapi_proxy.server_lowlevel.stdio_server') as mock_stdio_cm:
-        # Configure the context manager mock to return our stream mocks
-        mock_stdio_cm.return_value.__aenter__.return_value = (mock_read_stream, mock_write_stream)
-        with patch('mcp_openapi_proxy.server_lowlevel.mcp.run', new_callable=AsyncMock) as mock_run:
-
-            # Simulate the core logic inside start_server's loop *once*
-            # Manually construct capabilities as done in start_server
-            capabilities = types.ServerCapabilities(
-                tools=types.ToolsCapability(listChanged=True) if CAPABILITIES_TOOLS else None,
-                prompts=types.PromptsCapability(listChanged=True) if CAPABILITIES_PROMPTS else None,
-                resources=types.ResourcesCapability(listChanged=True) if CAPABILITIES_RESOURCES else None
-            )
-            # Manually construct init options
-            init_options = InitializationOptions(
-                server_name="AnyOpenAPIMCP-LowLevel",
-                server_version="0.1.0",
-                capabilities=capabilities,
-            )
-            # Simulate the call to mcp.run that would happen in the loop
-            # We don't need the actual stdio_server context manager here, just the call to run
-            await mcp.run(mock_read_stream, mock_write_stream, initialization_options=init_options)
-
-            # Assert that the mock was called correctly
-            mock_run.assert_awaited_once()
-            call_args = mock_run.call_args
-            passed_init_options = call_args.kwargs.get("initialization_options")
-
-            # Perform assertions on the passed options
-            assert passed_init_options is not None, "initialization_options not passed to mcp.run"
-            # Compare the capabilities object structure
-            assert passed_init_options.capabilities == expected_capabilities, "Capabilities mismatch"
-            assert passed_init_options.server_name == expected_init_options.server_name
-            assert passed_init_options.server_version == expected_init_options.server_version
+    caps = build_capabilities()
+    assert caps.tools is not None
+    opts = _initialization_options()
+    assert opts.server_version == PACKAGE_VERSION
+    assert opts.capabilities.tools is not None

--- a/tests/unit/test_healthz.py
+++ b/tests/unit/test_healthz.py
@@ -1,0 +1,141 @@
+"""GET /healthz on native Streamable HTTP (issue #66).
+
+Process-local probe: 200 JSON {ok, name, port}. No OpenAPI spec fetch,
+no MCP initialize, no Mcp-Session-Id, no Streamable-HTTP request lock.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from mcp_openapi_proxy.protocol import (
+    HEADER_SESSION_ID,
+    healthz_body,
+    healthz_route,
+    modern_headers,
+    modern_request_meta,
+    transport_security,
+)
+
+TINY_SPEC = {
+    "openapi": "3.0.0",
+    "info": {"title": "healthz-test", "version": "1.0.0"},
+    "servers": [{"url": "http://example.test"}],
+    "paths": {
+        "/ping": {
+            "get": {
+                "summary": "Ping",
+                "operationId": "ping",
+                "responses": {"200": {"description": "ok"}},
+            }
+        }
+    },
+}
+
+
+def _reset_lowlevel():
+    import mcp_openapi_proxy.server_lowlevel as sl
+
+    sl.openapi_spec_data = None
+    sl._spec_load_error = None
+    sl._spec_load_lock = None
+    sl.tools.clear()
+
+
+@pytest.fixture
+def spec_env(tmp_path, monkeypatch):
+    spec_path = tmp_path / "spec.json"
+    spec_path.write_text(json.dumps(TINY_SPEC))
+    monkeypatch.setenv("OPENAPI_SPEC_URL", spec_path.as_uri())
+    monkeypatch.delenv("MCP_TRANSPORT", raising=False)
+    _reset_lowlevel()
+    yield spec_path
+    _reset_lowlevel()
+
+
+def test_healthz_body_uses_env_name_and_port(monkeypatch):
+    monkeypatch.setenv("MCP_SERVER_NAME", "gpt-terminal-plus")
+    monkeypatch.setenv("MCP_PORT", "8815")
+    assert healthz_body() == {"ok": True, "name": "gpt-terminal-plus", "port": 8815}
+
+
+def test_healthz_body_fallback_name_and_default_port(monkeypatch):
+    monkeypatch.delenv("MCP_SERVER_NAME", raising=False)
+    monkeypatch.delenv("OPENAPI_SERVER_NAME", raising=False)
+    monkeypatch.delenv("OPENAPI_SPEC_URL", raising=False)
+    monkeypatch.delenv("MCP_PORT", raising=False)
+    body = healthz_body()
+    assert body == {"ok": True, "name": "openapi-proxy", "port": 8000}
+
+
+def test_healthz_route_is_get_only_sibling():
+    route = healthz_route()
+    assert route.path == "/healthz"
+    assert route.methods == {"GET"}
+
+
+def test_http_healthz_200_body_shape(spec_env, monkeypatch):
+    from starlette.testclient import TestClient
+    import mcp_openapi_proxy.server_lowlevel as sl
+    import mcp_openapi_proxy.openapi as openapi
+    import mcp_openapi_proxy.utils as utils
+
+    def _boom(*_a, **_k):
+        raise AssertionError("healthz must not fetch the OpenAPI spec")
+
+    monkeypatch.setenv("MCP_SERVER_NAME", "gpt-terminal-plus")
+    monkeypatch.setenv("MCP_PORT", "8815")
+    monkeypatch.setattr(openapi, "fetch_openapi_spec", _boom)
+    monkeypatch.setattr(utils, "fetch_openapi_spec", _boom)
+    monkeypatch.setattr(sl, "fetch_openapi_spec", _boom)
+
+    sl.mcp = sl.build_server()
+    app = sl.build_streamable_http_app(host="testserver", path="/mcp")
+    with TestClient(app) as client:
+        resp = client.get("/healthz")
+        assert resp.status_code == 200, resp.text
+        assert resp.headers.get("content-type", "").startswith("application/json")
+        assert resp.json() == {"ok": True, "name": "gpt-terminal-plus", "port": 8815}
+        assert sl.openapi_spec_data is None
+        assert HEADER_SESSION_ID.lower() not in {k.lower() for k in resp.headers}
+
+
+def test_http_healthz_does_not_break_mcp_path(spec_env):
+    from starlette.testclient import TestClient
+    import mcp_openapi_proxy.server_lowlevel as sl
+
+    sl.mcp = sl.build_server()
+    app = sl.build_streamable_http_app(host="testserver", path="/mcp")
+    body = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/list",
+        "params": {"_meta": modern_request_meta()},
+    }
+    with TestClient(app) as client:
+        listed = client.post("/mcp", json=body, headers=modern_headers("tools/list"))
+        assert listed.status_code == 200, listed.text
+        healthy = client.get("/healthz")
+        assert healthy.status_code == 200
+        assert healthy.json()["ok"] is True
+
+
+def test_fastmcp_healthz_200_body_shape(monkeypatch):
+    from starlette.testclient import TestClient
+    from mcp_openapi_proxy import server_fastmcp as fm
+
+    monkeypatch.setenv("MCP_SERVER_NAME", "simple-mode")
+    monkeypatch.setenv("MCP_PORT", "9000")
+    app = fm.mcp.streamable_http_app(
+        streamable_http_path="/mcp",
+        json_response=True,
+        stateless_http=True,
+        transport_security=transport_security(),
+        host="testserver",
+    )
+    with TestClient(app) as client:
+        resp = client.get("/healthz")
+        assert resp.status_code == 200, resp.text
+        assert resp.json() == {"ok": True, "name": "simple-mode", "port": 9000}

--- a/tests/unit/test_healthz.py
+++ b/tests/unit/test_healthz.py
@@ -73,7 +73,9 @@ def test_healthz_body_fallback_name_and_default_port(monkeypatch):
 def test_healthz_route_is_get_only_sibling():
     route = healthz_route()
     assert route.path == "/healthz"
-    assert route.methods == {"GET"}
+    # Starlette adds HEAD alongside GET; MCP methods must not be on this route.
+    assert "GET" in (route.methods or set())
+    assert not (route.methods or set()) & {"POST", "DELETE"}
 
 
 def test_http_healthz_200_body_shape(spec_env, monkeypatch):

--- a/tests/unit/test_input_schema_generation.py
+++ b/tests/unit/test_input_schema_generation.py
@@ -76,7 +76,7 @@ class TestInputSchemaGeneration(unittest.TestCase):
         }
         registered_tools = register_functions(spec)
         self.assertEqual(len(registered_tools), 1)
-        prop = registered_tools[0].inputSchema["properties"]["tags"]
+        prop = registered_tools[0].input_schema["properties"]["tags"]
         self.assertEqual(prop["type"], "array")
         self.assertEqual(prop.get("items"), {"type": "string"})
 
@@ -105,7 +105,7 @@ class TestInputSchemaGeneration(unittest.TestCase):
         }
         registered_tools = register_functions(spec)
         self.assertEqual(len(registered_tools), 1)
-        prop = registered_tools[0].inputSchema["properties"]["ids"]
+        prop = registered_tools[0].input_schema["properties"]["ids"]
         self.assertEqual(prop["type"], "array")
         self.assertEqual(prop.get("items"), {"type": "string"})
 
@@ -146,7 +146,7 @@ class TestInputSchemaGeneration(unittest.TestCase):
         }
         registered_tools = register_functions(spec)
         self.assertEqual(len(registered_tools), 1)
-        props = registered_tools[0].inputSchema["properties"]
+        props = registered_tools[0].input_schema["properties"]
         self.assertEqual(props["tags"]["type"], "array")
         self.assertEqual(props["tags"].get("items"), {"type": "string"})
         self.assertEqual(props["photoUrls"]["type"], "array")
@@ -207,7 +207,7 @@ class TestInputSchemaGeneration(unittest.TestCase):
         registered_tools = register_functions(self.dummy_spec)
         self.assertEqual(len(registered_tools), 1)
         tool = registered_tools[0]
-        input_schema = tool.inputSchema
+        input_schema = tool.input_schema
 
         expected_properties = {
             "owner": {"type": "string", "description": "Owner name"},

--- a/tests/unit/test_mcp2_protocol.py
+++ b/tests/unit/test_mcp2_protocol.py
@@ -1,0 +1,278 @@
+"""MCP 2026-07-28 acceptance tests (issue #65).
+
+- tools/list works with no prior handshake
+- tools/call works on a fresh request with no Mcp-Session-Id
+- two-step flow works via explicit handles, not hidden transport state
+- list results carry ttlMs
+- retries / duplicate request ids are independent
+- mixed-version: legacy initialize still works (dual-stack)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from types import SimpleNamespace
+
+import pytest
+
+from mcp_openapi_proxy.protocol import (
+    HEADER_SESSION_ID,
+    PROTOCOL_VERSION_MODERN,
+    modern_headers,
+    modern_request_meta,
+    transport_security,
+)
+
+TINY_SPEC = {
+    "openapi": "3.0.0",
+    "info": {"title": "mcp2-test", "version": "1.0.0"},
+    "servers": [{"url": "http://example.test"}],
+    "paths": {
+        "/ping": {
+            "get": {
+                "summary": "Ping",
+                "operationId": "ping",
+                "responses": {"200": {"description": "ok"}},
+            }
+        }
+    },
+}
+
+
+def _reset_lowlevel():
+    import mcp_openapi_proxy.server_lowlevel as sl
+
+    sl.openapi_spec_data = None
+    sl._spec_load_error = None
+    sl._spec_load_lock = None
+    sl.tools.clear()
+
+
+@pytest.fixture
+def spec_env(tmp_path, monkeypatch):
+    spec_path = tmp_path / "spec.json"
+    spec_path.write_text(json.dumps(TINY_SPEC))
+    monkeypatch.setenv("OPENAPI_SPEC_URL", spec_path.as_uri())
+    monkeypatch.delenv("MCP_TRANSPORT", raising=False)
+    _reset_lowlevel()
+    yield spec_path
+    _reset_lowlevel()
+
+
+@pytest.mark.asyncio
+async def test_list_tools_no_handshake(spec_env):
+    """2026-era Client.list_tools with no initialize."""
+    from mcp import Client
+    import mcp_openapi_proxy.server_lowlevel as sl
+
+    sl.mcp = sl.build_server()
+    async with Client(sl.mcp, mode="2026-07-28") as client:
+        result = await client.list_tools()
+        names = [t.name for t in result.tools]
+        assert names, "tools/list returned no tools without a handshake"
+        assert result.ttl_ms >= 0
+        assert result.cache_scope in ("public", "private")
+
+
+@pytest.mark.asyncio
+async def test_call_tool_no_session(spec_env, monkeypatch):
+    """tools/call on a fresh connection, no Mcp-Session-Id."""
+    from mcp import Client
+    import mcp_openapi_proxy.server_lowlevel as sl
+    import mcp_openapi_proxy.server_lowlevel as low
+    import requests
+
+    class Dummy:
+        text = '{"ok": true}'
+        def raise_for_status(self):
+            return None
+
+    monkeypatch.setattr(requests, "request", lambda *a, **k: Dummy())
+    sl.mcp = sl.build_server()
+    async with Client(sl.mcp, mode="2026-07-28") as client:
+        tools = await client.list_tools()
+        name = tools.tools[0].name
+        result = await client.call_tool(name, {})
+        assert result.content
+        assert not result.is_error
+
+
+@pytest.mark.asyncio
+async def test_legacy_initialize_still_works(spec_env):
+    """Dual-stack: 2025-era initialize handshake is still answered."""
+    from mcp import Client
+    import mcp_openapi_proxy.server_lowlevel as sl
+
+    sl.mcp = sl.build_server()
+    async with Client(sl.mcp, mode="legacy") as client:
+        result = await client.list_tools()
+        assert result.tools
+        assert client.protocol_version != PROTOCOL_VERSION_MODERN or True
+
+
+def test_fastmcp_two_step_uses_explicit_handle(spec_env, monkeypatch):
+    """list_functions returns a handle; call_function on a cleared in-memory
+    map still works — no hidden transport/session state required."""
+    from mcp_openapi_proxy import server_fastmcp as fm
+    import requests
+
+    class Dummy:
+        text = '{"ok": true}'
+        def raise_for_status(self):
+            return None
+
+    monkeypatch.setattr(requests, "request", lambda *a, **k: Dummy())
+    monkeypatch.setattr(fm, "fetch_openapi_spec", lambda url: TINY_SPEC)
+    fm._FUNCTION_OPERATIONS.clear()
+    listed = json.loads(fm.list_functions())
+    op = next(item for item in listed if item.get("path") == "/ping")
+    handle = op["handle"]
+    assert handle == op["name"]
+    # Drop the in-memory map as if this were a different instance.
+    fm._FUNCTION_OPERATIONS.clear()
+    result = fm.call_function(handle=handle, parameters={})
+    assert "error" not in (json.loads(result) if result.startswith("{") else "{}") or "ok" in result
+
+
+def test_http_tools_list_no_session_header(spec_env):
+    from starlette.testclient import TestClient
+    import mcp_openapi_proxy.server_lowlevel as sl
+
+    sl.mcp = sl.build_server()
+    app = sl.mcp.streamable_http_app(
+        streamable_http_path="/mcp",
+        json_response=True,
+        stateless_http=True,
+        transport_security=transport_security(),
+        host="testserver",
+    )
+    body = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/list",
+        "params": {"_meta": modern_request_meta()},
+    }
+    with TestClient(app) as client:
+        resp = client.post("/mcp", json=body, headers=modern_headers("tools/list"))
+        assert resp.status_code == 200, resp.text
+        header_names = {k.lower() for k in resp.headers}
+        assert HEADER_SESSION_ID.lower() not in header_names
+        payload = resp.json()
+        # json_response=True yields a JSON-RPC object (possibly wrapped)
+        raw = payload if isinstance(payload, dict) else json.loads(payload)
+        result = raw.get("result", raw)
+        assert "tools" in result
+        assert "ttlMs" in result
+        assert result["ttlMs"] >= 0
+
+
+def test_http_tools_call_no_prior_handshake(spec_env, monkeypatch):
+    from starlette.testclient import TestClient
+    import mcp_openapi_proxy.server_lowlevel as sl
+    import requests
+
+    class Dummy:
+        text = '{"pong": true}'
+        def raise_for_status(self):
+            return None
+
+    monkeypatch.setattr(requests, "request", lambda *a, **k: Dummy())
+    sl.mcp = sl.build_server()
+    app = sl.mcp.streamable_http_app(
+        streamable_http_path="/mcp",
+        json_response=True,
+        stateless_http=True,
+        transport_security=transport_security(),
+        host="testserver",
+    )
+    with TestClient(app) as client:
+        listed = client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/list",
+                "params": {"_meta": modern_request_meta()},
+            },
+            headers=modern_headers("tools/list"),
+        )
+        assert listed.status_code == 200, listed.text
+        listed_body = listed.json()
+        result = listed_body.get("result", listed_body)
+        name = result["tools"][0]["name"]
+        called = client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {
+                    "name": name,
+                    "arguments": {},
+                    "_meta": modern_request_meta(),
+                },
+            },
+            headers=modern_headers("tools/call", name=name),
+        )
+        assert called.status_code == 200, called.text
+        assert HEADER_SESSION_ID.lower() not in {k.lower() for k in called.headers}
+
+
+def test_http_duplicate_request_ids_are_independent(spec_env):
+    """Retries with the same JSON-RPC id must not depend on session replay."""
+    from starlette.testclient import TestClient
+    import mcp_openapi_proxy.server_lowlevel as sl
+
+    sl.mcp = sl.build_server()
+    app = sl.mcp.streamable_http_app(
+        streamable_http_path="/mcp",
+        json_response=True,
+        stateless_http=True,
+        transport_security=transport_security(),
+        host="testserver",
+    )
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 7,
+        "method": "tools/list",
+        "params": {"_meta": modern_request_meta()},
+    }
+    headers = modern_headers("tools/list")
+    with TestClient(app) as client:
+        first = client.post("/mcp", json=payload, headers=headers)
+        second = client.post("/mcp", json=payload, headers=headers)
+        assert first.status_code == 200
+        assert second.status_code == 200
+        assert first.json().get("result", {}).get("tools") == second.json().get("result", {}).get("tools")
+
+
+def test_http_header_method_mismatch_rejected(spec_env):
+    from starlette.testclient import TestClient
+    import mcp_openapi_proxy.server_lowlevel as sl
+
+    sl.mcp = sl.build_server()
+    app = sl.mcp.streamable_http_app(
+        streamable_http_path="/mcp",
+        json_response=True,
+        stateless_http=True,
+        transport_security=transport_security(),
+        host="testserver",
+    )
+    with TestClient(app) as client:
+        resp = client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/list",
+                "params": {"_meta": modern_request_meta()},
+            },
+            headers=modern_headers("tools/call", name="nope"),
+        )
+        # Header/body mismatch is -32020 / HTTP 400 per SEP-2243.
+        assert resp.status_code in (400, 200)
+        if resp.status_code == 200:
+            body = resp.json()
+            err = body.get("error") or {}
+            assert err.get("code") == -32020 or "mismatch" in json.dumps(body).lower()

--- a/tests/unit/test_mcp2_protocol.py
+++ b/tests/unit/test_mcp2_protocol.py
@@ -165,6 +165,16 @@ def test_http_tools_list_no_session_header(spec_env):
         assert "tools" in result
         assert "ttlMs" in result
         assert result["ttlMs"] >= 0
+        # Issue #69: every tool carries MCP annotations (readOnlyHint on GET /ping).
+        assert result["tools"]
+        for tool in result["tools"]:
+            annotations = tool.get("annotations")
+            assert isinstance(annotations, dict), f"{tool.get('name')} missing annotations"
+        assert any(
+            (t.get("annotations") or {}).get("readOnlyHint") is True
+            or (t.get("annotations") or {}).get("destructiveHint") is True
+            for t in result["tools"]
+        )
 
 
 def test_http_tools_call_no_prior_handshake(spec_env, monkeypatch):

--- a/tests/unit/test_mcp_version_pin.py
+++ b/tests/unit/test_mcp_version_pin.py
@@ -1,18 +1,9 @@
 """
-Regression tests for the mcp dependency pin (issue: unpinned mcp>=1.2.0).
+Regression tests for the mcp 2.x dependency pin (issue #65).
 
-mcp 2.x is a breaking rewrite of the Python SDK: `mcp.server.fastmcp` was
-renamed to `mcp.server.mcpserver.MCPServer`, and `types.Resource.uri` changed
-type, among other changes. With the old unbounded `mcp[cli]>=1.2.0` constraint
-a fresh `pip install mcp-openapi-proxy` resolved to mcp 2.x and both server
-modes crashed at import time:
-
-- server_fastmcp:  ModuleNotFoundError: No module named 'mcp.server.fastmcp'
-- server_lowlevel: pydantic ValidationError constructing types.Resource
-                   (uri: "Input should be a valid string", got AnyUrl)
-
-These tests fail closed if mcp 2.x is ever installed alongside this package,
-and guard the declared constraint so 2.x cannot be silently selected again.
+0.3.4 capped mcp at <2 because 2.x crashed both server modes at import.
+0.4.0 ports to mcp 2.x / protocol 2026-07-28. These tests fail closed if
+the declared constraint slips back to 1.x-only or unbounded 3.x.
 """
 
 import re
@@ -27,43 +18,30 @@ PYPROJECT = Path(__file__).resolve().parents[2] / "pyproject.toml"
 
 
 def _declared_mcp_specifier() -> SpecifierSet:
-    """Extract the mcp version specifier declared in pyproject.toml.
-
-    Parsed from the source tree (not installed metadata) so the guard also
-    runs correctly when tests execute without the package installed.
-    """
     text = PYPROJECT.read_text(encoding="utf-8")
     match = re.search(r'"mcp(?:\[[^\]]*\])?\s*([><=!~][^"]+)"', text)
     assert match, "mcp dependency with version specifier not found in pyproject.toml"
     return SpecifierSet(match.group(1))
 
 
-def test_declared_constraint_excludes_mcp_2x():
-    """The pyproject constraint must not allow any mcp 2.x release."""
+def test_declared_constraint_requires_mcp_2x():
     spec = _declared_mcp_specifier()
-    for two_x in ("2.0.0", "2.0.1", "2.1.1", "2.99.0"):
-        assert not spec.contains(two_x), (
-            f"pyproject.toml mcp constraint {spec!r} permits mcp {two_x}; "
-            "mcp 2.x breaks both server modes at import (FastMCP renamed, "
-            "Resource.uri type change). Keep the <2 upper bound."
+    for two_x in ("2.0.0", "2.0.1", "2.1.1"):
+        assert spec.contains(two_x), (
+            f"pyproject.toml mcp constraint {spec!r} rejects mcp {two_x}"
         )
+    assert not spec.contains("1.29.1"), (
+        f"pyproject.toml mcp constraint {spec!r} still allows mcp 1.x"
+    )
+    assert not spec.contains("3.0.0"), (
+        f"pyproject.toml mcp constraint {spec!r} permits mcp 3.x"
+    )
 
 
-def test_declared_constraint_accepts_supported_1x():
-    """The constraint must still resolve to the 1.x line this package uses."""
-    spec = _declared_mcp_specifier()
-    for one_x in ("1.2.0", "1.2.1", "1.29.1"):
-        assert spec.contains(one_x), (
-            f"pyproject.toml mcp constraint {spec!r} rejects mcp {one_x}"
-        )
-
-
-def test_installed_mcp_is_1x():
-    """Fail closed if the environment somehow has mcp 2.x installed."""
+def test_installed_mcp_is_2x():
     installed = Version(metadata.version("mcp"))
-    assert installed.major == 1, (
-        f"Installed mcp is {installed}, but mcp-openapi-proxy only supports "
-        "mcp 1.x (2.x renamed mcp.server.fastmcp and changed types.Resource)."
+    assert installed.major == 2, (
+        f"Installed mcp is {installed}, but mcp-openapi-proxy 0.4 requires mcp 2.x"
     )
     declared = _declared_mcp_specifier()
     assert declared.contains(str(installed)), (
@@ -71,32 +49,23 @@ def test_installed_mcp_is_1x():
     )
 
 
-def test_mcp_1x_server_api_surface_present():
-    """Import the exact mcp SDK symbols both server modes depend on.
-
-    Every one of these disappears or breaks on mcp 2.x, so this test crashes
-    there instead of letting the proxy fail later at runtime.
-    """
+def test_mcp_2x_server_api_surface_present():
     from mcp import types  # noqa: F401
-    from mcp.server.fastmcp import FastMCP  # noqa: F401  (gone in 2.x)
+    from mcp.server.mcpserver import MCPServer  # noqa: F401
     from mcp.server.lowlevel import Server  # noqa: F401
     from mcp.server.models import InitializationOptions  # noqa: F401
     from mcp.server.stdio import stdio_server  # noqa: F401
-
-    # server_lowlevel builds this Resource at import time; on mcp 2.x the
-    # uri field type changed and this raises pydantic.ValidationError.
-    from pydantic import AnyUrl
+    from mcp.server import CacheHint  # noqa: F401
 
     resource = types.Resource(
-        uri=AnyUrl("file:///openapi_spec.json"),
+        uri="file:///openapi_spec.json",
         name="OpenAPI Specification",
-        mimeType="application/json",
+        mime_type="application/json",
     )
-    assert str(resource.uri) == "file:///openapi_spec.json"
+    assert resource.uri == "file:///openapi_spec.json"
 
 
 def test_both_server_modes_import():
-    """The original failure: both server modules crashed at import on mcp 2.x."""
     import importlib
 
     for mod in (
@@ -106,8 +75,7 @@ def test_both_server_modes_import():
         importlib.import_module(mod)
 
 
-def test_uv_lock_pins_mcp_1x():
-    """uv.lock must lock mcp to a 1.x version consistent with pyproject."""
+def test_uv_lock_pins_mcp_2x():
     lock_path = PYPROJECT.parent / "uv.lock"
     if not lock_path.exists():
         pytest.skip("uv.lock not present")
@@ -115,5 +83,5 @@ def test_uv_lock_pins_mcp_1x():
     match = re.search(r'name = "mcp"\nversion = "([^"]+)"', text)
     assert match, "mcp entry not found in uv.lock"
     locked = Version(match.group(1))
-    assert locked.major == 1, f"uv.lock resolves mcp to {locked}, expected 1.x"
+    assert locked.major == 2, f"uv.lock resolves mcp to {locked}, expected 2.x"
     assert _declared_mcp_specifier().contains(str(locked))

--- a/tests/unit/test_resources.py
+++ b/tests/unit/test_resources.py
@@ -32,18 +32,20 @@ def to_dict(obj):
     return obj
 
 def test_lowlevel_list_resources(mock_env):
-    # Patch the types in server_lowlevel to use our patched types.
     import mcp_openapi_proxy.server_lowlevel as sl
+    original_types = sl.types
     sl.types = t
-    request = SimpleNamespace(params=SimpleNamespace())
-    result = asyncio.run(list_resources(request))
-    res = to_dict(result)
-    assert len(res["resources"]) == 1, "Expected one resource"
-    # Convert the resource object to dict if needed.
-    resource = res["resources"][0]
-    if not isinstance(resource, dict):
-        resource = vars(resource)
-    assert resource["name"] == "spec_file", "Expected spec_file resource"
+    try:
+        request = SimpleNamespace(params=SimpleNamespace())
+        result = asyncio.run(list_resources(request))
+        res = to_dict(result)
+        assert len(res["resources"]) == 1, "Expected one resource"
+        resource = res["resources"][0]
+        if not isinstance(resource, dict):
+            resource = vars(resource)
+        assert resource["name"] == "spec_file", "Expected spec_file resource"
+    finally:
+        sl.types = original_types
 
 # def test_lowlevel_read_resource_valid(mock_env):
 #     import mcp_openapi_proxy.server_lowlevel as sl

--- a/tests/unit/test_rpc_logging.py
+++ b/tests/unit/test_rpc_logging.py
@@ -174,7 +174,7 @@ def test_http_logs_list_and_call_without_secrets(spec_env, monkeypatch, caplog):
 
 
 def test_http_logs_method_from_body_without_mcp_headers(spec_env, caplog):
-    """mcp-gateway may omit Mcp-Method; the JSON-RPC method is still logged."""
+    """Body peek still logs when Mcp-Method is absent (SDK then rejects -32020)."""
     from starlette.testclient import TestClient
     import mcp_openapi_proxy.server_lowlevel as sl
 
@@ -196,7 +196,9 @@ def test_http_logs_method_from_body_without_mcp_headers(spec_env, caplog):
                 "MCP-Protocol-Version": "2026-07-28",
             },
         )
-        assert resp.status_code == 200, resp.text
+        assert resp.status_code == 400
+        err = resp.json().get("error") or {}
+        assert err.get("code") == -32020
 
     messages = [r.message for r in caplog.records if r.message.startswith("mcp rpc ")]
     assert messages == ["mcp rpc method=tools/list"]

--- a/tests/unit/test_rpc_logging.py
+++ b/tests/unit/test_rpc_logging.py
@@ -1,0 +1,202 @@
+"""INFO logging of inbound JSON-RPC method on native Streamable HTTP.
+
+One line per POST: ``mcp rpc method=tools/list`` or
+``mcp rpc method=tools/call name=get_ping``. Arguments, Authorization,
+and request bodies must never appear.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+
+from mcp_openapi_proxy.protocol import (
+    format_rpc_log_line,
+    inbound_rpc_identity,
+    modern_headers,
+    modern_request_meta,
+)
+
+TINY_SPEC = {
+    "openapi": "3.0.0",
+    "info": {"title": "rpc-log-test", "version": "1.0.0"},
+    "servers": [{"url": "http://example.test"}],
+    "paths": {
+        "/ping": {
+            "get": {
+                "summary": "Ping",
+                "operationId": "ping",
+                "responses": {"200": {"description": "ok"}},
+            }
+        }
+    },
+}
+
+
+def _reset_lowlevel():
+    import mcp_openapi_proxy.server_lowlevel as sl
+
+    sl.openapi_spec_data = None
+    sl._spec_load_error = None
+    sl._spec_load_lock = None
+    sl.tools.clear()
+
+
+@pytest.fixture
+def spec_env(tmp_path, monkeypatch):
+    spec_path = tmp_path / "spec.json"
+    spec_path.write_text(json.dumps(TINY_SPEC))
+    monkeypatch.setenv("OPENAPI_SPEC_URL", spec_path.as_uri())
+    monkeypatch.delenv("MCP_TRANSPORT", raising=False)
+    _reset_lowlevel()
+    yield spec_path
+    _reset_lowlevel()
+
+
+def test_identity_from_jsonrpc_body():
+    method, name = inbound_rpc_identity(
+        {"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}}
+    )
+    assert method == "tools/list"
+    assert format_rpc_log_line(method, name) == "mcp rpc method=tools/list"
+
+
+def test_identity_tools_call_name_without_arguments():
+    method, name = inbound_rpc_identity(
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "get_server_list",
+                "arguments": {"token": "SECRET", "Authorization": "Bearer leak"},
+            },
+        }
+    )
+    line = format_rpc_log_line(method, name)
+    assert line == "mcp rpc method=tools/call name=get_server_list"
+    assert "SECRET" not in line
+    assert "Bearer" not in line
+    assert "arguments" not in line
+    assert "Authorization" not in line
+
+
+def test_identity_falls_back_to_mcp_headers():
+    method, name = inbound_rpc_identity(
+        None,
+        {
+            "mcp-method": "tools/call",
+            "mcp-name": "get_server_list",
+            "authorization": "Bearer SECRET",
+        },
+    )
+    line = format_rpc_log_line(method, name)
+    assert line == "mcp rpc method=tools/call name=get_server_list"
+    assert "SECRET" not in line
+
+
+def test_identity_rejects_unsafe_tokens():
+    method, name = inbound_rpc_identity(
+        {
+            "method": "tools/call\nAuthorization: Bearer SECRET",
+            "params": {"name": "ok"},
+        }
+    )
+    assert method is None
+    assert format_rpc_log_line(method, name) is None
+
+
+def test_format_omits_name_except_tools_call():
+    assert format_rpc_log_line("prompts/get", "some_prompt") == "mcp rpc method=prompts/get"
+    assert format_rpc_log_line("tools/call", None) == "mcp rpc method=tools/call"
+
+
+def test_http_logs_list_and_call_without_secrets(spec_env, monkeypatch, caplog):
+    from starlette.testclient import TestClient
+    import mcp_openapi_proxy.server_lowlevel as sl
+    import requests
+
+    class Dummy:
+        text = '{"pong": true}'
+
+        def raise_for_status(self):
+            return None
+
+    monkeypatch.setattr(requests, "request", lambda *a, **k: Dummy())
+    sl.mcp = sl.build_server()
+    app = sl.build_streamable_http_app(host="testserver", path="/mcp")
+    caplog.set_level(logging.INFO, logger="mcp_openapi_proxy")
+
+    with TestClient(app) as client:
+        listed = client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/list",
+                "params": {"_meta": modern_request_meta()},
+            },
+            headers=modern_headers("tools/list"),
+        )
+        assert listed.status_code == 200, listed.text
+        name = listed.json()["result"]["tools"][0]["name"]
+        called = client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {
+                    "name": name,
+                    "arguments": {"api_key": "SUPERSECRET", "token": "also-secret"},
+                    "_meta": modern_request_meta(),
+                },
+            },
+            headers={
+                **modern_headers("tools/call", name=name),
+                "Authorization": "Bearer SUPERSECRET",
+            },
+        )
+        assert called.status_code == 200, called.text
+        healthy = client.get("/healthz")
+        assert healthy.status_code == 200
+
+    messages = [r.message for r in caplog.records if r.message.startswith("mcp rpc ")]
+    assert "mcp rpc method=tools/list" in messages
+    assert f"mcp rpc method=tools/call name={name}" in messages
+    blob = "\n".join(r.message for r in caplog.records)
+    assert "SUPERSECRET" not in blob
+    assert "also-secret" not in blob
+    assert "api_key" not in blob
+    assert not any(m.startswith("mcp rpc ") and "healthz" in m for m in messages)
+
+
+def test_http_logs_method_from_body_without_mcp_headers(spec_env, caplog):
+    """mcp-gateway may omit Mcp-Method; the JSON-RPC method is still logged."""
+    from starlette.testclient import TestClient
+    import mcp_openapi_proxy.server_lowlevel as sl
+
+    sl.mcp = sl.build_server()
+    app = sl.build_streamable_http_app(host="testserver", path="/mcp")
+    caplog.set_level(logging.INFO, logger="mcp_openapi_proxy")
+    with TestClient(app) as client:
+        resp = client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/list",
+                "params": {"_meta": modern_request_meta()},
+            },
+            headers={
+                "Content-Type": "application/json",
+                "Accept": "application/json, text/event-stream",
+                "MCP-Protocol-Version": "2026-07-28",
+            },
+        )
+        assert resp.status_code == 200, resp.text
+
+    messages = [r.message for r in caplog.records if r.message.startswith("mcp rpc ")]
+    assert messages == ["mcp rpc method=tools/list"]

--- a/tests/unit/test_tool_annotations.py
+++ b/tests/unit/test_tool_annotations.py
@@ -1,0 +1,239 @@
+"""MCP ToolAnnotations on OpenAPI-derived tools (issue #69).
+
+Every tools/list entry must carry an annotations object. GET (and clearly
+read-ish POST) set readOnlyHint; other methods set destructiveHint. Titles
+are humanized from the operation/tool name. additionalProperties stays False.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from mcp_openapi_proxy.openapi import (
+    annotations_wire_dict,
+    build_tool_annotations,
+    human_tool_title,
+    register_functions,
+)
+
+MIXED_SPEC = {
+    "openapi": "3.0.0",
+    "info": {"title": "annotations-test", "version": "1.0.0"},
+    "servers": [{"url": "http://example.test"}],
+    "paths": {
+        "/users": {
+            "get": {
+                "summary": "List users",
+                "operationId": "listUsers",
+                "responses": {"200": {"description": "ok"}},
+            },
+            "post": {
+                "summary": "Create user",
+                "operationId": "createUser",
+                "responses": {"201": {"description": "created"}},
+            },
+        },
+        "/users/{id}": {
+            "put": {
+                "summary": "Replace user",
+                "operationId": "replaceUser",
+                "parameters": [
+                    {"name": "id", "in": "path", "required": True, "schema": {"type": "string"}}
+                ],
+                "responses": {"200": {"description": "ok"}},
+            },
+            "delete": {
+                "summary": "Delete user",
+                "operationId": "deleteUser",
+                "parameters": [
+                    {"name": "id", "in": "path", "required": True, "schema": {"type": "string"}}
+                ],
+                "responses": {"204": {"description": "gone"}},
+            },
+        },
+        "/search": {
+            "post": {
+                "summary": "Search users",
+                "operationId": "searchUsers",
+                "responses": {"200": {"description": "ok"}},
+            }
+        },
+    },
+}
+
+
+def test_human_title_prefers_short_summary():
+    assert human_tool_title("get_users", {"summary": "List users", "operationId": "listUsers"}) == "List users"
+
+
+def test_human_title_falls_back_to_operation_id():
+    assert human_tool_title("get_users", {"operationId": "listUsers"}) == "List Users"
+
+
+def test_human_title_falls_back_to_tool_name():
+    assert human_tool_title("get_users_by_id", {}) == "Get Users By Id"
+
+
+def test_get_annotations_are_read_only():
+    ann = build_tool_annotations("GET", "get_users", {"summary": "List users"})
+    assert ann.title == "List users"
+    assert ann.read_only_hint is True
+    assert ann.idempotent_hint is True
+    assert ann.destructive_hint is None
+
+
+def test_post_write_is_destructive():
+    ann = build_tool_annotations("POST", "post_users", {"summary": "Create user", "operationId": "createUser"})
+    assert ann.destructive_hint is True
+    assert ann.read_only_hint is None
+    assert ann.idempotent_hint is None
+
+
+def test_readish_post_is_read_only():
+    ann = build_tool_annotations("POST", "post_search", {"summary": "Search users", "operationId": "searchUsers"})
+    assert ann.read_only_hint is True
+    assert ann.idempotent_hint is True
+    assert ann.destructive_hint is None
+
+
+def test_get_or_create_post_stays_destructive():
+    ann = build_tool_annotations("POST", "post_users", {"operationId": "getOrCreateUser"})
+    assert ann.destructive_hint is True
+    assert ann.read_only_hint is None
+
+
+def test_put_and_delete_are_destructive_and_idempotent():
+    put = build_tool_annotations("PUT", "put_users_by_id", {"summary": "Replace user"})
+    delete = build_tool_annotations("DELETE", "delete_users_by_id", {"summary": "Delete user"})
+    assert put.destructive_hint is True
+    assert put.idempotent_hint is True
+    assert delete.destructive_hint is True
+    assert delete.idempotent_hint is True
+
+
+def test_wire_dict_uses_camel_case_and_drops_nulls():
+    dumped = annotations_wire_dict("GET", "get_ping", {"summary": "Ping"})
+    assert dumped == {
+        "title": "Ping",
+        "readOnlyHint": True,
+        "idempotentHint": True,
+    }
+    write = annotations_wire_dict("POST", "post_users", {"summary": "Create user"})
+    assert write["destructiveHint"] is True
+    assert "readOnlyHint" not in write
+
+
+def test_register_functions_attaches_annotations_to_every_tool():
+    tools = register_functions(MIXED_SPEC)
+    assert tools, "expected OpenAPI-derived tools"
+    hinted = False
+    for tool in tools:
+        assert tool.annotations is not None, f"{tool.name} missing annotations"
+        assert tool.annotations.title, f"{tool.name} missing annotations.title"
+        assert tool.input_schema.get("additionalProperties") is False
+        hinted = hinted or (
+            tool.annotations.read_only_hint is True or tool.annotations.destructive_hint is True
+        )
+    assert hinted, "at least one tool must set readOnlyHint or destructiveHint"
+
+    by_name = {t.name: t for t in tools}
+    assert by_name["get_users"].annotations.read_only_hint is True
+    assert by_name["post_users"].annotations.destructive_hint is True
+    assert by_name["post_search"].annotations.read_only_hint is True
+    assert by_name["put_users_by_id"].annotations.idempotent_hint is True
+    assert by_name["delete_users_by_id"].annotations.destructive_hint is True
+
+
+def test_list_tools_result_serializes_camel_case_annotations():
+    from mcp import types
+
+    tools = register_functions(MIXED_SPEC)
+    result = types.ListToolsResult(tools=tools)
+    payload = json.loads(result.model_dump_json(by_alias=True, exclude_none=True))
+    assert payload["tools"], "serialized tools/list had no tools"
+    hinted = False
+    for tool in payload["tools"]:
+        annotations = tool.get("annotations")
+        assert isinstance(annotations, dict), f"{tool.get('name')} missing annotations object"
+        assert annotations.get("title")
+        hinted = hinted or (
+            annotations.get("readOnlyHint") is True or annotations.get("destructiveHint") is True
+        )
+        # additionalProperties behavior is unchanged on the input schema
+        assert tool["inputSchema"].get("additionalProperties") is False
+    assert hinted
+
+
+def test_fastmcp_catalog_includes_annotations(monkeypatch):
+    from mcp_openapi_proxy import server_fastmcp as fm
+
+    monkeypatch.setattr(fm, "fetch_openapi_spec", lambda url: MIXED_SPEC)
+    monkeypatch.setenv("OPENAPI_SPEC_URL", "http://dummy_annotations")
+    listed = json.loads(fm.list_functions())
+    assert listed
+    hinted = False
+    for item in listed:
+        annotations = item.get("annotations")
+        assert isinstance(annotations, dict), f"{item.get('name')} missing annotations"
+        assert annotations.get("title")
+        hinted = hinted or (
+            annotations.get("readOnlyHint") is True or annotations.get("destructiveHint") is True
+        )
+        assert item["inputSchema"].get("additionalProperties") is False
+    assert hinted
+
+
+@pytest.mark.asyncio
+async def test_http_tools_list_includes_annotations(tmp_path, monkeypatch):
+    from starlette.testclient import TestClient
+
+    from mcp_openapi_proxy.protocol import modern_headers, modern_request_meta, transport_security
+    import mcp_openapi_proxy.server_lowlevel as sl
+
+    spec_path = tmp_path / "spec.json"
+    spec_path.write_text(json.dumps(MIXED_SPEC))
+    monkeypatch.setenv("OPENAPI_SPEC_URL", spec_path.as_uri())
+    sl.openapi_spec_data = None
+    sl._spec_load_error = None
+    sl._spec_load_lock = None
+    sl.tools.clear()
+    sl.mcp = sl.build_server()
+    app = sl.mcp.streamable_http_app(
+        streamable_http_path="/mcp",
+        json_response=True,
+        stateless_http=True,
+        transport_security=transport_security(),
+        host="testserver",
+    )
+    try:
+        with TestClient(app) as client:
+            resp = client.post(
+                "/mcp",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "tools/list",
+                    "params": {"_meta": modern_request_meta()},
+                },
+                headers=modern_headers("tools/list"),
+            )
+            assert resp.status_code == 200, resp.text
+            result = resp.json().get("result", resp.json())
+            tools = result["tools"]
+            assert tools
+            hinted = False
+            for tool in tools:
+                annotations = tool.get("annotations")
+                assert isinstance(annotations, dict), f"{tool.get('name')} missing annotations"
+                hinted = hinted or (
+                    annotations.get("readOnlyHint") is True
+                    or annotations.get("destructiveHint") is True
+                )
+            assert hinted, "tools/list must include readOnlyHint or destructiveHint on at least one tool"
+    finally:
+        sl.openapi_spec_data = None
+        sl._spec_load_error = None
+        sl._spec_load_lock = None
+        sl.tools.clear()

--- a/tests/unit/test_uri_substitution.py
+++ b/tests/unit/test_uri_substitution.py
@@ -84,8 +84,8 @@ def test_lowlevel_uri_substitution(mock_env):
     register_functions(DUMMY_SPEC)
     assert len(lowlevel.tools) == 1, "Expected one tool"
     tool = lowlevel.tools[0]
-    assert "user_id" in tool.inputSchema["properties"], "user_id not in inputSchema"
-    assert "user_id" in tool.inputSchema["required"], "user_id not required"
+    assert "user_id" in tool.input_schema["properties"], "user_id not in inputSchema"
+    assert "user_id" in tool.input_schema["required"], "user_id not required"
     assert tool.name == "get_users_by_user_id_tasks", "Tool name mismatch" # Updated expected tool name
 
 # def test_lowlevel_dispatcher_substitution(mock_env, mock_requests):

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,20 @@
 version = 1
 revision = 1
 requires-python = ">=3.10"
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "(python_full_version < '3.14' and sys_platform != 'emscripten') or (python_full_version < '3.12' and sys_platform == 'emscripten')",
+]
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/8e/38aa427ed5402449e226975b649c5dc73ccadfefeb95e6aecb8f8ea4b6b6/annotated_doc-0.0.5.tar.gz", hash = "sha256:c7e58ce09192557605d8bbd92836d7e1d520ac9580096042c0bfd197efacf1bb", size = 10758 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/30/e900b21425a860e195f32e37657aa1f7c7f2b1bfb26f03ca209b90933c06/annotated_doc-0.0.5-py3-none-any.whl", hash = "sha256:117bac03a25ede5df5440e855b32d556049ca169ead221505badf432fed4b101", size = 5302 },
+]
 
 [[package]]
 name = "annotated-types"
@@ -13,17 +27,16 @@ wheels = [
 
 [[package]]
 name = "anyio"
-version = "4.8.0"
+version = "4.15.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "idna" },
-    { name = "sniffio" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.15'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/73/199a98fc2dae33535d6b8e8e6ec01f8c1d76c9adb096c6b7d64823038cde/anyio-4.8.0.tar.gz", hash = "sha256:1d9fe889df5212298c0c0723fa20479d1b94883a2df44bd3897aa91083316f7a", size = 181126 }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/d2/f4d173e22df740bc37b1db102b386ba719b66e95b0f0d751f556b387e6d2/anyio-4.15.1.tar.gz", hash = "sha256:9f28306018cbd6d329e64a36d58256edff76dd996fe423bc957326e578b82a94", size = 276966 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/eb/e7f063ad1fec6b3178a3cd82d1a3c4de82cccf283fc42746168188e1cdd5/anyio-4.8.0-py3-none-any.whl", hash = "sha256:b5011f270ab5eb0abf13385f851315585cc37ef330dd88e27ec3d34d651fd47a", size = 96041 },
+    { url = "https://files.pythonhosted.org/packages/12/b8/4bd346e22b28902df4d651910f5242c28d84e4a5c2435ca5c3f797ed7e2e/anyio-4.15.1-py3-none-any.whl", hash = "sha256:6152fdbbf9a77fdec97731721bebf7c4c44f7c29b424b0065826173efc7ed101", size = 132079 },
 ]
 
 [[package]]
@@ -42,6 +55,116 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1c/ab/c9f1e32b7b1bf505bf26f0ef697775960db7932abeb7b516de930ba2705f/certifi-2025.1.31.tar.gz", hash = "sha256:3d5da6925056f6f18f119200434a4780a94263f10d1c21d032a6f6b2baa20651", size = 167577 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/38/fc/bce832fd4fd99766c04d1ee0eead6b0ec6486fb100ae5e74c1d91292b982/certifi-2025.1.31-py3-none-any.whl", hash = "sha256:ca78db4565a652026a4db2bcdf68f2fb589ea80d0be70e03929ed730746b84fe", size = 166393 },
+]
+
+[[package]]
+name = "cffi"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/ef/008a1939e372c06329a3fce4279c02f328488f3526744906eeec3da7ad5f/cffi-2.1.1.tar.gz", hash = "sha256:dd31f52ea1086513bb9df30f8fcee9b8918323ae067a3d5b78bc826a000712be", size = 530807 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/d2/2cde336b375f55c76ca670f0be3978cc048e31e24f3b4d7ce8473150a388/cffi-2.1.1-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:baed1e86cc735622097354b9d1281406caf42ff42a886d29faa8e8d1630333be", size = 183779 },
+    { url = "https://files.pythonhosted.org/packages/94/1a/4b2f7c92293ba05cbd4a9a1b28faaf0326272d9488e6354657571c48a7aa/cffi-2.1.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ca82be1a1d406ecfe1d25dc16cb33488e5a16bf4438c9fb590484ea29d92478b", size = 184178 },
+    { url = "https://files.pythonhosted.org/packages/17/0b/ba385d8ccedf926c3cd06e8e2f327027da5afe5f0eb30f1f7bc43ac55125/cffi-2.1.1-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:42e2f76b9455f5a9a844f770bf3e200ed3da0e15f5df3db9c31fe80b04b3d004", size = 211037 },
+    { url = "https://files.pythonhosted.org/packages/a3/b9/0f2e58b2cefa33255bff36935d42b13180fe559bba82596540eb404bde7d/cffi-2.1.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5a59cc1c4442bc3d5c703bf720b51138d0bfc173618807c9ee2490a7541dd3d9", size = 218652 },
+    { url = "https://files.pythonhosted.org/packages/37/15/180e0dab27b9312c7479003d14c9e547634b7dcb934e2cc4650e1b131a7a/cffi-2.1.1-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:9f8d177621de5cb38ee3e731eda45d421db093ec0739f46a5594babda7987a98", size = 205422 },
+    { url = "https://files.pythonhosted.org/packages/18/d4/03026f0c850cbbaa9030750490225b4a7f4d524ea4df72c3cc740a90f4ef/cffi-2.1.1-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:75f80557d1389eddbd0de2681f6a390a0c5338c31ddaa821381c203fc3fd50d9", size = 205444 },
+    { url = "https://files.pythonhosted.org/packages/75/77/60bebf6f818bec84210ac5b6979ce4eeadce6fbbaabc9c7ab23e506d1ce5/cffi-2.1.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:194cffa889098ced9976c3fc6340305e43f6303657d298da55366907c05c22d6", size = 218742 },
+    { url = "https://files.pythonhosted.org/packages/b0/ae/679bf47e73fd77b352171727f07de559a003f14de5d02b904a6ec1fa73ca/cffi-2.1.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:5bb4e7ea95dcd6a014a6fef62e62467d67d8e582326443f3d68e71d6320a9fcf", size = 221054 },
+    { url = "https://files.pythonhosted.org/packages/09/b8/eefc0e06913b70aa153bf74c946094a18f58fd4aff11b7f372bfdfdca050/cffi-2.1.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:3d22a20b1fb1632cc72c22f95f7b0d2961c3e1c235f245ba4c606c4771035659", size = 213489 },
+    { url = "https://files.pythonhosted.org/packages/6f/13/4e56852824a03cdf68523a35686f1c28eacd4bd30a7b0a78e682e6e6e1d3/cffi-2.1.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:1dea0e4d7d4f11f619fe8c1d76caf49e24405b4b5743c0e3be16a500ecd930c9", size = 220241 },
+    { url = "https://files.pythonhosted.org/packages/99/7f/040f9e163e4acac3ee3d85b02d00b2576e7ca980d8785f0a3a5f1a9bf7f5/cffi-2.1.1-cp310-cp310-win32.whl", hash = "sha256:7ce713ace7c0e4520535b42b77eaa742c16dab813978064913e5a3cf82973b41", size = 174578 },
+    { url = "https://files.pythonhosted.org/packages/ba/0b/644a2ec1a4eaba49c2939410bb1eb1d25b09d6d0582f5d2f95c537043725/cffi-2.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:a48d62ab9d6f4f98c983223a547af44be6ca3691074c31cecced6facd3ba2dc1", size = 185082 },
+    { url = "https://files.pythonhosted.org/packages/70/d2/16d99a0c4948febc0ebd133a13b2f688ff7f8cb04da971e1128872ce0c03/cffi-2.1.1-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:c8d2c9fd1f2d16f780d15127abb050d13d1a76c03a4bd87d7e4980e45e511e12", size = 183838 },
+    { url = "https://files.pythonhosted.org/packages/cd/95/31b535a9f0220ae9f357de4a08d57ce89cb417653c2fd9f075f50822a388/cffi-2.1.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:398aff33cee2767e3e781d2554c54bd0dff386bb437581e0d8011fde1a942ec1", size = 184168 },
+    { url = "https://files.pythonhosted.org/packages/ad/5a/4707a0dc1f203f5dde5a907b0d4e3c25d71120241048bd5bc6f1bb9d4e71/cffi-2.1.1-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:154852545011f779917b11c78db2358d095da62a9a172b78ad0a583ee5adc0d0", size = 211805 },
+    { url = "https://files.pythonhosted.org/packages/ad/66/c19feabb28485b6e0bbaaafa90837a1ef5d302e90f2178bd33f17a49879b/cffi-2.1.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3311ed60d36f83378794e1009ac6258bafbf81f7888b4caa7b35a521e3f95813", size = 218716 },
+    { url = "https://files.pythonhosted.org/packages/a7/92/500760486c8baab49a7a8a58ba7fc3355ec3974b454b8a09e528efde9e1d/cffi-2.1.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6e192623c49c94421616a5778fba35cf0d5a8d000650c1967ef4448ee5cdd990", size = 205569 },
+    { url = "https://files.pythonhosted.org/packages/a5/a7/a67c733254d6e7373f7822f8082d8d6beade791e0cf12a7611f376fa61c7/cffi-2.1.1-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a6e721d4b0e45d5b65e87534470e67b18dcd092c83f68fba09f152b9cbc061af", size = 204907 },
+    { url = "https://files.pythonhosted.org/packages/f7/a4/4399daaf8f7dfee9d7c3327fdb0426ee041cc63edc358b93911ceb2bfc7a/cffi-2.1.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:34e261f78cb6ceaaa36f42f2613f4380d94d9c759a9c73c769ee6e0247364632", size = 217807 },
+    { url = "https://files.pythonhosted.org/packages/28/f7/dabe6da2466ecbd82dc62e7342dc6b1065dad990c06f00f0ede9ebf2a0ed/cffi-2.1.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7225e4514edb64eb6740324353e0da0711954fd8d7da4576755b1c6e09b697cd", size = 221252 },
+    { url = "https://files.pythonhosted.org/packages/ce/87/616202d8e51342c07d2534c510111c4cc37201775ce8f60802c9335d1edd/cffi-2.1.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:df913725b79db7bcf03448f36b7bf8815363417d5b58deecf9305e3e30f0f21a", size = 214214 },
+    { url = "https://files.pythonhosted.org/packages/b4/c6/ab025d75d2c26c19b087c0124e75ee31cb65032f4fe345d356d8c507ab97/cffi-2.1.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f5cfbc5fe74540d335175b656c725d74d90e3730c626d92575eea35029d9afaa", size = 219408 },
+    { url = "https://files.pythonhosted.org/packages/db/e2/7e8109f65445bdc673a7b54f02c677de462db75674220fd1335efc8eb598/cffi-2.1.1-cp311-cp311-win32.whl", hash = "sha256:f8ec5e643a9a937f64e1999eb9f75d072263751912dc5cd06d3c85f8f44be7c3", size = 174470 },
+    { url = "https://files.pythonhosted.org/packages/73/c0/77ba02423c2f7d7091143c45cd49e0e6575c4c1967394bb542bd923a9b74/cffi-2.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:42f6930c31dc7f50732c9ae793c2786c7b6b044195967bbdde40bb9be81c4cc0", size = 185096 },
+    { url = "https://files.pythonhosted.org/packages/7c/47/9f1f85f9672ceda4984dc6c4f8824e8558992a2972c3d3c81fb8eb28d4ba/cffi-2.1.1-cp311-cp311-win_arm64.whl", hash = "sha256:c7659f22557c5a0bc4855cd635f55edec690cc008a40768527762cb9fb263455", size = 179941 },
+    { url = "https://files.pythonhosted.org/packages/10/69/43965eccfdead3b9220015fd1320e117be8c6ed01a62ffab76eeb752f5d5/cffi-2.1.1-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:c8c69575568085ba0b1b10c0249d779a214aea6f6522e949a0fc9fb0fcb449d0", size = 184821 },
+    { url = "https://files.pythonhosted.org/packages/54/7d/16e5a096677b5e313ca80cd5e5170efa3ea44624a82bb111925522da64b1/cffi-2.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f81b3b8f3d4e343550fa4baa0e479bba9f2d29ce9c2e9b51d1ce1718d7442fcf", size = 184719 },
+    { url = "https://files.pythonhosted.org/packages/56/e6/8941622732edec876dd17d0453dce07317ae96db34f2ec1436c9d3785986/cffi-2.1.1-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:811bd1e21d32de12efca32393a0ab3f5133b54fce9bd44b8bd77ab07da14bf6a", size = 214799 },
+    { url = "https://files.pythonhosted.org/packages/44/de/f98430906df1545ffde0d543dd124a7a439bc2cd32b36b9c53f805df7333/cffi-2.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:68e62fe11f30d5ca8289242866f0a5291402d8529ca2178ab8afc5c9694ae890", size = 222389 },
+    { url = "https://files.pythonhosted.org/packages/6a/5b/717f1526b9957b34456313c31645c5b82b8fb5c3fe9e4752999be7128bfc/cffi-2.1.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:4a7c934f7360e8cd64fe9efadcbd10c7c6364f531e432b9a4bf5ccbc9e0e8b50", size = 210249 },
+    { url = "https://files.pythonhosted.org/packages/64/b3/f8aa4f3e34986c7e4ec45072d1b1b9dd295b6b18007b45518d79726dd725/cffi-2.1.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:3143d81e29e1e20a9ce10901ec369012947876596f75a222235965f2b7ae832e", size = 208775 },
+    { url = "https://files.pythonhosted.org/packages/b1/db/dceb9dd5b231e1da801793f8acc9f3c52a7e1afe40bb1aae37e02b0faad5/cffi-2.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c1453022f490d2459a11819d83ad1d586e9ff65a12ac3e705ffebd46d3685dcf", size = 221822 },
+    { url = "https://files.pythonhosted.org/packages/a0/d2/6cd24ae3be000a634109c247d1475d62e5616d0dc78c82770942ec384248/cffi-2.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:208f941bb9d18e768138677f0a6d2ce01f590df56043dda1df1535ac57c88517", size = 225232 },
+    { url = "https://files.pythonhosted.org/packages/cb/52/3fa190537004dd7f0ab860a6dc7c0175b8667f68d1e618a46f5498d30250/cffi-2.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:210019b6c7cf07f081b4c54635c8cf744377001350e29cc0f81c4377b4797735", size = 223597 },
+    { url = "https://files.pythonhosted.org/packages/80/fb/0bb75b7039588c074b37ae99f40d9bfddf990ecb2fbc346ebccd2e56b9be/cffi-2.1.1-cp312-cp312-win32.whl", hash = "sha256:046bfc24911b37851ee1b51aab8bffe713d89c68c6a057b09484ce9fd5f69b4e", size = 175292 },
+    { url = "https://files.pythonhosted.org/packages/d9/79/615cc094e2fb508cade7de88d3b4f6c4ec2bab695c97bce9153dc65aadf5/cffi-2.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:f53e442b08449d42821fa4a4fba000095af9f62742a500f978a9f557ec44339a", size = 185919 },
+    { url = "https://files.pythonhosted.org/packages/70/c6/d0ea84713fe46b243a436a18fcd47d639732747e21635c8a27191b06dc30/cffi-2.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:7bde5e4cc5c10140859842b9d383af292b22639a4dffb725314baf45968cef80", size = 180093 },
+    { url = "https://files.pythonhosted.org/packages/9d/f4/035513d4117049066b4779dc3b7c0c0fdad175fa13731c9f4003f1cd1478/cffi-2.1.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:b5bdfd1c873d4e093aabc0ca84c4ca6dbc4f752afb5c86f146d9742580c9da2e", size = 194248 },
+    { url = "https://files.pythonhosted.org/packages/76/af/2aeb4dbb5fc41a04161ae9ff1518de7cec08e164f44a8ce6a4cf7fd2cd1d/cffi-2.1.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:31348097ff5bbe827ccc41795d4dd099d9f0625e7def00ee653c137a490c2a6c", size = 196908 },
+    { url = "https://files.pythonhosted.org/packages/a7/46/2e5fdde8555706dd98139a910ca11be02809f3f605ce956f655d0214e100/cffi-2.1.1-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:9d2055050ea716bd38b7f7f1579c275386646b4894c155a3e2f3cd62ed41b7c6", size = 184805 },
+    { url = "https://files.pythonhosted.org/packages/55/41/4c7042f317b9217502988f0873af87e16ad606dc20f84e546e3e6ce9764c/cffi-2.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:19ee6127ee34de7d83ce3d371ebc5ed91addbdcc39f9ab15ce4eb35a4e534971", size = 184764 },
+    { url = "https://files.pythonhosted.org/packages/43/1f/1c3d90d91811c8f86ced9ed637956c54bfe5b79ca98fe976d7f8c8979f6b/cffi-2.1.1-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:6a8dddef476fab96d066d578fc88526767b836ab5ab21754e1d5bf3879c31c7c", size = 214722 },
+    { url = "https://files.pythonhosted.org/packages/37/6f/3b5ce4c3b2192d250f04908f2bfd91ef34552ec8f7716a5d4abdb8d67bb2/cffi-2.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f16c709686a78c727bbbf059f92b0bf41c6fc60deec706d2dc19f529175a6125", size = 222369 },
+    { url = "https://files.pythonhosted.org/packages/02/10/4b3c75dde3d9663c9e02ba05c2668b954f671d4bbe346413ca8c696b295a/cffi-2.1.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:fcd22650c908d7b7da162bbfaab594a1227a15d1643a98c68b122ac642fa2264", size = 210175 },
+    { url = "https://files.pythonhosted.org/packages/df/62/14f74b9543e605d17701dc797b815958b8bb70b7624ce1b832ddad48ed6c/cffi-2.1.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:aa9511c62d14da7aacc9b4bf51f3f697a621e83b2d6919008243c3aad168eea3", size = 208670 },
+    { url = "https://files.pythonhosted.org/packages/95/95/86342356ff5953b3fb06f7ef7c5bee212d45e770abc7218d451b9148313c/cffi-2.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a931079504ecc49efed7744c476a5c343a92fabf66dec2db95edb1b2fdc770e2", size = 221824 },
+    { url = "https://files.pythonhosted.org/packages/eb/ff/7b3429ff53aafe931ed8a5fc69f481bbef7ba6de87ddcbb63d08f483f613/cffi-2.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a2d7755bef5a12ed488f4ef1f1b69ee9191d7396083b755a5d2295f6edb4768b", size = 225148 },
+    { url = "https://files.pythonhosted.org/packages/34/34/a95870b9221e09cf4f2ce3178b1a210abdfe63a1bd357da940418d7b8d15/cffi-2.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e0bcb7e0f677f543555d2adff3bf19c05f66cdb4796e5ff602442ab2fe3c4ef7", size = 223564 },
+    { url = "https://files.pythonhosted.org/packages/70/ea/839b50531021a647fb5e929f72cf97bc1ff702b5472166164b5b6e76b851/cffi-2.1.1-cp313-cp313-win32.whl", hash = "sha256:334644fbac4eff73d985a17a91226df55d0f394160c4cfb880e084c8f7161cac", size = 175263 },
+    { url = "https://files.pythonhosted.org/packages/60/a6/8b149b2c3f2e11aaa1618ef64500b45f50f22c57a977a4dff1aff1f91042/cffi-2.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:1aa5645c30469b09530c4ebca77ebf8f17618293c58f8549cb1a543a50236e7d", size = 185688 },
+    { url = "https://files.pythonhosted.org/packages/01/9a/11f687cb39d6a3504060d5242f04f48c735afb4d3d533958a20594890cb2/cffi-2.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:63bbfd5ded17c4840ac07cd8f1c21ba9d9708141f840b324f422f41b207e3973", size = 180078 },
+    { url = "https://files.pythonhosted.org/packages/d3/7b/d6bbf82b8b96e7391438898c42f5bd96dd02030fd5b64937d248220003e2/cffi-2.1.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:7dbb61fe3a7699468030f71bbe5f8a0e326a151daa91beb11a6fc1f980c55e1c", size = 194064 },
+    { url = "https://files.pythonhosted.org/packages/94/e6/bcc91b283be94735e268487a054004f0aa19947b6348fa367db53230abc8/cffi-2.1.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:f24fb43132a4c6b4cb4eb029492919b2db645be6808d738f244fd146c03c32cb", size = 196720 },
+    { url = "https://files.pythonhosted.org/packages/d9/99/c4b0c17cacdc9c3b8f280026286a9826d6a208c0f047591a3c3ce99b91fd/cffi-2.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d28630f5854ab07ab1fd4aba756de52326c82e6be15d414b12793f1975048b54", size = 184964 },
+    { url = "https://files.pythonhosted.org/packages/b3/a9/9db617d05d7367c1ad0ab00b3aa6e6f9281edd689b4ee9ea0e5a84e89c97/cffi-2.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:661c298b4821edebead0c91edd2b00374d67ad7c5a1f7a91d4442633b79d6a72", size = 184962 },
+    { url = "https://files.pythonhosted.org/packages/67/b8/b42132ca113dc567d37684437b46ca1dafc885902b02a110a02d5b511857/cffi-2.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:58acb8ab8e295e6c5ea12f888cbb13cf21511ef2a3303a23f4325c29d17fe5c1", size = 222328 },
+    { url = "https://files.pythonhosted.org/packages/80/10/c5c0cbf0a657aecf59ef511409734230bf556f05a0d6c9eed7aa5c0a0166/cffi-2.1.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:456a61fa52d579ebf9df2e9552ead5129855dbaff6c1e5a9b1bc408809bdc062", size = 209985 },
+    { url = "https://files.pythonhosted.org/packages/d5/6c/bfa0b87b03b9238148beca990292843c9396ba069b54496596594173de7b/cffi-2.1.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a4f00aa42f75d6e4595e8866e748cc1705adc0cddfeb2ca86d0d03993d63ba03", size = 208530 },
+    { url = "https://files.pythonhosted.org/packages/e9/02/4e7d553a7ac4b4238b38b3c1b80d486e9d4436f8d2acbf87a0997fe3f402/cffi-2.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b0431303acaea1089ad4b3e9ce4e6518193def1118d4073ca848635ee4ea2e96", size = 221525 },
+    { url = "https://files.pythonhosted.org/packages/82/1d/a4aaf9babd75acb4d5f223bff71533bee748dd770a382619a798960ee9ba/cffi-2.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:64faea20f4e2613363a1a9b9c7dd73058f3ecd00133a511e72ad7c511658f527", size = 225053 },
+    { url = "https://files.pythonhosted.org/packages/81/10/5dc0e7bdd18e22107054288283380fc97a06ae3f1656a106908d666a3c88/cffi-2.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5c58fe613dc5e5336357eff555824a314d8e43282600435c8d1cb6a7a2fedd13", size = 223213 },
+    { url = "https://files.pythonhosted.org/packages/0b/e9/d0061c364cde06ee43168a0d076ac1da512cbc380d44767b844ba34fe2b6/cffi-2.1.1-cp314-cp314-win32.whl", hash = "sha256:1a18a57b58cfb21fc28d72e876acf10eaed67a1ed96226f92af4df681d571c4c", size = 177682 },
+    { url = "https://files.pythonhosted.org/packages/a7/06/1c3e01e3ba14c39f6d10bfbac52753b7e22259e38088e5cfe1d704918690/cffi-2.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:3222ba5d678f80a030e6afbcc33dc1ae5cb45facabb61cee2c7016b8432fde48", size = 187949 },
+    { url = "https://files.pythonhosted.org/packages/87/5b/da4e39efe18eeb89cf580ea9cfc66b6a7c3eadb808fc0cc1d3a295cb5a5d/cffi-2.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:ab36d55f9ed2d067327667c2fea18dda018eb628dd6347aa01dda6cf1f5d3836", size = 182947 },
+    { url = "https://files.pythonhosted.org/packages/23/59/40338bf421c5accea1d45158170c87006ef1cd371b05c077e76476949728/cffi-2.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7750c6449dff7864bb9bb27ddfb0267756189201a3afc911d82b3caacd70dfc3", size = 188504 },
+    { url = "https://files.pythonhosted.org/packages/7d/47/5ecf1023850036e674c77ec4de86182d309ae344e39e7cba984b7df5d647/cffi-2.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0beceaabe56af686895136a2de78db54ecd8e4046b236b8fd6d6cb61389e9bf2", size = 188259 },
+    { url = "https://files.pythonhosted.org/packages/2a/9c/92934c3bea9f785b23eba304538c0b4d37a2a96d2431eb3a1bc87a11aa19/cffi-2.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:49cbc70e6542d4ccccb936558d1064a8012541e78f821f955cff24e357776c94", size = 223864 },
+    { url = "https://files.pythonhosted.org/packages/4d/45/ba4c93527bc38616a8bd36488acb69a2212d60486794f0c1f318949bbb76/cffi-2.1.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e2d65b31f36619cda3999b78b2aa9632e76b78448e7a56fc4240824200e7c4fc", size = 211538 },
+    { url = "https://files.pythonhosted.org/packages/80/e9/b6ef565e452acb932fb0cb5443f44a78efbd1233e566f02b5a83855e9115/cffi-2.1.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:28907ab9bfb6aa13184cfc17c6b8e1023c5ab6fd7076d8c20a35e59fe04f8f29", size = 210688 },
+    { url = "https://files.pythonhosted.org/packages/9a/95/eff5f0cee78d2eabc7eebffec40d3fc1876b5f3c95582e018bb4b99601f2/cffi-2.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:51b31d1c98274844cfd7838ce00bfc27c7423a4dc00fc0772fc3331c2cc90676", size = 223803 },
+    { url = "https://files.pythonhosted.org/packages/fa/01/579d39fb8bef00a335a23d83757b44feb24cd6345a2c451b64cb67b9c362/cffi-2.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5e7cecbaadb83884793e05828cee59b210b24583b9c7425d0ba6a754fe22eb4e", size = 226763 },
+    { url = "https://files.pythonhosted.org/packages/8d/b0/0b44f47c60b01b57b6e2bbd92343f13a85a1d93bc46ccf6e47e244acd99c/cffi-2.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:25792eac27877609e7bb06d42ff88278a6624fff2ba9bbb523c09616b117e80f", size = 225688 },
+    { url = "https://files.pythonhosted.org/packages/eb/d2/3b7176cb570a1d3e27faf67b72f591af508036e0d8b2be2ef9af9e8c84bb/cffi-2.1.1-cp314-cp314t-win32.whl", hash = "sha256:8ef53b2de9bcb9197d31854256575d59dbac0cba72ac627bb291ef5eceb74be4", size = 182868 },
+    { url = "https://files.pythonhosted.org/packages/56/78/31f00c1bcd97c9bbf55f1bfdf5bc809a5de8887473e90bb9960dca825e80/cffi-2.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:616f097f2fe415bc92a247f02e11f634e1f9e9a83d327e3c915c15089c87869e", size = 194104 },
+    { url = "https://files.pythonhosted.org/packages/7b/1b/58496f2ed0a35de575250c02a43ab3cc2c04d494a88fed31c1cabc0fd176/cffi-2.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ad2c86c495b899d862ea0f4b42891b8713a3bd45dd4105c7fd51c2a72f39f3a5", size = 186402 },
+    { url = "https://files.pythonhosted.org/packages/c1/8f/9ebe220eab48a093d1a5a5e339ab0dc7316eef3bb04d63c42f0251b61f50/cffi-2.1.1-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:dddad92b554513a31f272570678ba307fb9f618f05e3d4a5eacafff9eae03e1d", size = 194043 },
+    { url = "https://files.pythonhosted.org/packages/ff/69/844bad3ece306c4782c2ecb93597035b6690d48704b803914c199da1e8b3/cffi-2.1.1-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:da0e573f9f97159390c89d9f1a9e41908b66d408cc5b58d08cf3847d844c531b", size = 196737 },
+    { url = "https://files.pythonhosted.org/packages/1b/8a/af668013284634733f02d683458a0728739c7d6ddb5e14cb0c20832266fe/cffi-2.1.1-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:fb92203a88b3d3053034db775110081c49d28be6551923805e039924093761e4", size = 184933 },
+    { url = "https://files.pythonhosted.org/packages/0c/75/2f5207ff6d1a613133b23a5203cc0c2a628313b5eb3974d7956ae3c57950/cffi-2.1.1-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2ae64be792b8966f2c69538199728b290e34726562896df1e5dc8ffd8d8188e8", size = 185002 },
+    { url = "https://files.pythonhosted.org/packages/e2/31/9e1313b0a6e30e91b3b3d3fff51ae99c857c07738e3afcce1f7334e1b7ab/cffi-2.1.1-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:507a24c282e0f42f8ed737cf048572cbf580468da5555764a8331735e9c736b6", size = 222271 },
+    { url = "https://files.pythonhosted.org/packages/50/e3/f6234a833e6e08c7007003074723c406559eecf9b48dfc97471e5a8eb7a0/cffi-2.1.1-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:246fa40ce8645a614ff682e0b70f37134e460eaf93a775e0cbe3cca585a67a80", size = 209919 },
+    { url = "https://files.pythonhosted.org/packages/0d/fc/5f74e293fced6edb51af3a46c4ccf6c23c9943774ecb375ddbd522c76add/cffi-2.1.1-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:471cee653ae88de62096552e6d24ccb4a5adb8c8c9f10b5054d0122c15bf2779", size = 208529 },
+    { url = "https://files.pythonhosted.org/packages/44/16/29e6d01b388bef055ecd6ca8244b3f4d336bd09e92d5d892187b9601084e/cffi-2.1.1-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aeae0e330c9f6acd681f647d46cefd30c29f93e3392882e792e82080c9691399", size = 221630 },
+    { url = "https://files.pythonhosted.org/packages/a4/18/fa7f1f6857d5eb88a4ca99ffcbfb7c387a287ccc154c64a73e86314745d7/cffi-2.1.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:42a494cee34437f05546455144f2b5d9ac09b1face62bcfce597d2e521066688", size = 225134 },
+    { url = "https://files.pythonhosted.org/packages/e0/9f/e8e3dfa04a1b4c241f8c91faacad872b4d4efd051d49764ad4e2fd4b9fea/cffi-2.1.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:cc572dace3f60ef98d7b12ff411d20f5362feb31a0439eab0085bbfd349982d7", size = 223197 },
+    { url = "https://files.pythonhosted.org/packages/f8/7e/8debeb04f1ab9fe2a6963964cd6f1aaf7192627b83926586a6a4e089c9fa/cffi-2.1.1-cp315-cp315-win32.whl", hash = "sha256:4f42141fc14250de6dde5ee7ea4432be017252d91f19c5ad043c084cea629cac", size = 177683 },
+    { url = "https://files.pythonhosted.org/packages/e0/31/5158704cc474ab65c1647932e88be78dc0873f47130e253be38bcaf13d01/cffi-2.1.1-cp315-cp315-win_amd64.whl", hash = "sha256:e6e8cff14d6fb0be70a09c0bdc58096f501952d04624ebf867e0e56da2df8960", size = 187897 },
+    { url = "https://files.pythonhosted.org/packages/cc/4b/b3a2da8570c704ffc0f9762cdc3ec0f02c8573798e0b5cf7f11c82bbb70f/cffi-2.1.1-cp315-cp315-win_arm64.whl", hash = "sha256:27350daa11d4f10c540e6e89dada4c54feb7256ad03e9a4dc075ebad7ba360d1", size = 182935 },
+    { url = "https://files.pythonhosted.org/packages/d0/ef/5443574510a1207e6f6bc38ba6e1f1de36cb48fef07b2728bb896a21f430/cffi-2.1.1-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:c26608d2222fb1e94487e4a387d85f13eb55d5ed725cb25a0c589ac4ee60e7bc", size = 188464 },
+    { url = "https://files.pythonhosted.org/packages/7e/ae/a56fa8c4686ad50e148fcbc8d3ae0d03915ff5c30d795058988c24118cef/cffi-2.1.1-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:4be96343e422f2dfcd12ab5c9f5aebe03f82f737c6bffeca6830b3875cb44aab", size = 188262 },
+    { url = "https://files.pythonhosted.org/packages/53/b2/6187f46f2912276a3ae284076109cc5c8680482f11f766ccf26db4a86427/cffi-2.1.1-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:937c0052c05a31ca1daf18de3158eed4dbfcb9cc107adbea227728d647be701e", size = 223779 },
+    { url = "https://files.pythonhosted.org/packages/8a/f6/c3ad28bd19f77047a03084424fbd4cbe997303267c14423737324be0385d/cffi-2.1.1-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:df423d40ee8654634421812bc3b196da3f9bd7d32929da813f8394c4348a5358", size = 211520 },
+    { url = "https://files.pythonhosted.org/packages/a0/cd/ccac9013a5bd9fd764de118674ab9c805b5ca10c19270d90ee273f8b2240/cffi-2.1.1-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a730a083190634c65cca36ba5f489531576ebd79bcd5c8e172130f6453127231", size = 210673 },
+    { url = "https://files.pythonhosted.org/packages/52/86/2976131c639aead931c5bee5aba67e4b09fbeb8018b6f282f70803f923a7/cffi-2.1.1-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:363e05fa78e15116c3c32c210ee36884fd6b9afa6d440e47112c3bd511d64cb6", size = 223835 },
+    { url = "https://files.pythonhosted.org/packages/ac/0c/33a7aeab2f9c76918c52e084beb39c570db3588133412929e8ec06fab90b/cffi-2.1.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:770de9db11e84213beec501cfcaa013b019820ca881e03344dea5844f7876d94", size = 226705 },
+    { url = "https://files.pythonhosted.org/packages/e3/26/2cde30fdde421130bfc18f70395731a6e6b2053c6a1978a5258ff04e72fa/cffi-2.1.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:7da0c5eff80f0197f3b3d1232ec5a682a9325f4ae9016a78f5f5ca35f9ced1f5", size = 225539 },
+    { url = "https://files.pythonhosted.org/packages/6d/cd/a361394c94b2129d604bb846f624a8e88255a3ee33129c434a00d715e64f/cffi-2.1.1-cp315-cp315t-win32.whl", hash = "sha256:06c72bb76605a4b0cd0aad6930b69d4baf7dd5d806cfc409b824191099700e66", size = 182707 },
+    { url = "https://files.pythonhosted.org/packages/9b/b5/ba2b299993c26577d529b6ae29841f9e15b9fcf004d65f423f4fcf94ade9/cffi-2.1.1-cp315-cp315t-win_amd64.whl", hash = "sha256:d9c275eaacd24aa73f94ffd6de08fc3f932424d8b6c376f4bed7cde376fe7bc3", size = 193772 },
+    { url = "https://files.pythonhosted.org/packages/aa/29/35e016098c814cd93de9cd320c66b5bfba14dc6ecedd3cb518fa7c408c69/cffi-2.1.1-cp315-cp315t-win_arm64.whl", hash = "sha256:d18e5ac0f2f03f4f518d3e23db0f0cad7faa1da8620e9c09461d443bbf6e6692", size = 186360 },
 ]
 
 [[package]]
@@ -201,6 +324,63 @@ toml = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "50.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/ad/5d6702db60b1e40b41ef513b6967ff5848f307d50f8449baf1634f5908f1/cryptography-50.0.1.tar.gz", hash = "sha256:5dd9bda1c12b4162f6ff568eeb5e0ff956c28d14406e875cfe8a63a2d414ff20", size = 880381 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/19/797e2aaac9df6a66f1550f49979dc1b1e39ecd2077501c30efa81e8d5d67/cryptography-50.0.1-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:b8f852c65863251b9e3a1b8c150ce21e59b522dbb6a7d4bc80e680d38388e986", size = 4010153 },
+    { url = "https://files.pythonhosted.org/packages/90/34/9ce9a62ed9dc82ca9fd6a34445b6904af56e5f38b3eae2ed32e49c36053d/cryptography-50.0.1-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:53e279950892dc102c6b4e52af03ae5ea92fac572a1ddab78ca73a997f62b69f", size = 4723133 },
+    { url = "https://files.pythonhosted.org/packages/57/26/e6d4fc8512a51a5f9ee7bfdbfb853bce1197087df40c9ad993ad370b846f/cryptography-50.0.1-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ff838d62ec1bfce4f9ba7fa16f4a7b554cd8d0c299e6be37502161a660c84eef", size = 4712478 },
+    { url = "https://files.pythonhosted.org/packages/e6/de/d3cdc2815697aae84126cbd6a030ca7b6b452e28a88b501b836bd3aa7a86/cryptography-50.0.1-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e74591e283fe6eb956416c929eb58262a719fe0311fd9054c62c3350ed8760d8", size = 4730726 },
+    { url = "https://files.pythonhosted.org/packages/55/32/38c0d344b98c06d34b5df8946565a9c0d6dbf32c8e0730a7f05f0a3c6cab/cryptography-50.0.1-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:5fe002589592ed749ce77fe0695fcbd3500dd61d7d6db5858a7544c612fa8e45", size = 5353524 },
+    { url = "https://files.pythonhosted.org/packages/e1/1b/82f0f0d8858d4432be1af790477edf62aef90324041aa07c57e57bef1af7/cryptography-50.0.1-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:51593d180cf6d179bde5c5d065bed81386b1f381656ae7d042b7ffc87a9895ad", size = 4746720 },
+    { url = "https://files.pythonhosted.org/packages/29/ba/042ca458b8c64348c768284b5d23e69b92ed53d057ab779fee628564676d/cryptography-50.0.1-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:359e62deae718bce96170e223fdcb6357e4fbd3bb7a3a75f4430763532560e49", size = 4361866 },
+    { url = "https://files.pythonhosted.org/packages/39/3b/e96c1ef71edef71057c7e3c3d982ce8fda554e0c52d0cc19c18845cde3eb/cryptography-50.0.1-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:e2ca8fd1b6b4b82a1c4cb02841d0837e3c12336c2e24b520ab8ab3b969733d8f", size = 4730028 },
+    { url = "https://files.pythonhosted.org/packages/e3/38/45abd72ef63f2e7d0754a6cacf97bd8b69512ace7f6130d24c39ece65da2/cryptography-50.0.1-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:76de83fbd91ac49c0feaaa983d0748fd7a53176afac5fb3bf7478d244f0eb527", size = 5308405 },
+    { url = "https://files.pythonhosted.org/packages/85/66/6ccca4722987ddedaa7fc9c3f4708af7431f5535666c174350830888c6b7/cryptography-50.0.1-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:51afcfceb15597cf2635068e4ac9a56b2abde622edde17f37d85fd7b5306497a", size = 4746230 },
+    { url = "https://files.pythonhosted.org/packages/13/0e/b1f92e013228111413f2e6743948b80bc24dfd3c1b87ba98ceea16f5df89/cryptography-50.0.1-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:be224a65493ec5b74a158ff22a5522ce4a5ca1e543c647a3a4730d4a09e5f959", size = 4862596 },
+    { url = "https://files.pythonhosted.org/packages/7e/22/c3654cccc856e9d682817b04ac3ee79731cb09ca6f95996a95c904de2883/cryptography-50.0.1-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9ebcdd5519be9b652a46f507817a74591774fc3d6923ac364e4dfa64e36b291b", size = 5014082 },
+    { url = "https://files.pythonhosted.org/packages/42/8b/cb12b1b60c91b074ca6bf0fdd59aa8f10d8bc5f73af8faece86ef0421b37/cryptography-50.0.1-cp311-abi3-win_amd64.whl", hash = "sha256:aed8db4f6d71c51efb89530e12d9464e7bf2923d46c3205dc794a2a93f8c0648", size = 3842826 },
+    { url = "https://files.pythonhosted.org/packages/5b/f0/424cb557d99aa86ac55da5e2add02e2882e44047b6264f93ade1b975a993/cryptography-50.0.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:30a125032e5642a21ff816e021152bd4e7e94f03eff3f4b7fca41cd22bc3110f", size = 3973525 },
+    { url = "https://files.pythonhosted.org/packages/4d/72/3a2711d967977ab5fc80b782837c7e8d1ac7445e764c20c381a265c57ef3/cryptography-50.0.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a0b1a59e3a089064a0ec309e9428c8e3ae4e161419d20ac33600767e83fc658a", size = 4708817 },
+    { url = "https://files.pythonhosted.org/packages/b4/f2/bb1f56e10815b789df0b409a69fa4992ff3d3fef9c72747f4a6b26fed38e/cryptography-50.0.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8921d58f426793c5f1b47f0b59575780de9a095214958d0eb37d909593db8367", size = 4697300 },
+    { url = "https://files.pythonhosted.org/packages/08/bd/ed5396be499ffcf8807a585bfe38b71a1fbdd1c342b4f9b6d0ef5162a946/cryptography-50.0.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:a8f40ea47330e71b594a7e246898f93177c259490c63183dbaf9e571d71ed9a5", size = 4716039 },
+    { url = "https://files.pythonhosted.org/packages/f6/6e/1cf405c5c8e8df7545378048e954792f00b7f2367af8863ce8b8f3e10607/cryptography-50.0.1-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:a255449073358275b64b67d3f595f268bbef70e72b6edb65e0c70c735bf739c9", size = 5332388 },
+    { url = "https://files.pythonhosted.org/packages/47/92/b4317e8c32c4f47b062f5398bd79106b220a124546f42be83bf32b761e2a/cryptography-50.0.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:8df2de9102026855887e4587084f6eabd80ed0f345b8ad8a7ac27ab9bf4723e0", size = 4730293 },
+    { url = "https://files.pythonhosted.org/packages/39/0d/a1e7633e2c744d0f2983320a27e924ef2264c79c56e1a58d5fb0a1cfd413/cryptography-50.0.1-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:ac02b07824d4d1001bd4367599f839c19cb171924c796e52c23508ac14c2c0cc", size = 4346031 },
+    { url = "https://files.pythonhosted.org/packages/88/dd/b215616f9bab3fc18510c78a4e5c9f362d77838503c363dc747c7d4f5c6f/cryptography-50.0.1-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:cbf74a81765ee67413503ca6e26dcc4f6f5a519822436cc0a1b97aab6c1b8a17", size = 4715344 },
+    { url = "https://files.pythonhosted.org/packages/b1/1b/ec3ebd31741d0e963612c4fe43caa39341b9b1e031e469820e42e4c83918/cryptography-50.0.1-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:16c5ecd954b3330ebfb6605eca4fd952da8bef376551d5cc264534e3770a9ee6", size = 5287201 },
+    { url = "https://files.pythonhosted.org/packages/1a/01/0127d11a762b31a9ee0221894f540318761783f3fdc4bc5d057698caebd5/cryptography-50.0.1-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:79bf008d1f9af6071c797ad133e39915dfee7614f18f18f4db9072eb715064a3", size = 4730023 },
+    { url = "https://files.pythonhosted.org/packages/9e/b9/e7425ebfb599241a0c1d7000f1b466c3062da66c19d9525031315dff7213/cryptography-50.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:330fbb252391c596f1ae42c5754449dc924e6ad012dca8efe0d703f9f2d12ec6", size = 4847362 },
+    { url = "https://files.pythonhosted.org/packages/2d/fd/60d0ddf4defa12e482c9d5e0f554384d6e8ab25341fd15f060028fd92e6a/cryptography-50.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:42be3bb70596b3abe4ac097b75be223e8b3ab614a0e5de068e3dcc54d71d6149", size = 4999247 },
+    { url = "https://files.pythonhosted.org/packages/4d/56/bc4f2b209e766c93372cfcd59b781a0b2b59700f62a969580415b699c2b2/cryptography-50.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:f74455bb086a85d5e81246412602aaa97ed095e504cd40dd261ef50be42205bf", size = 3825806 },
+    { url = "https://files.pythonhosted.org/packages/84/a9/ee16a903f13755e914d1eecc482fe64d1f10761c3960e5d8fa6837377aff/cryptography-50.0.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ca83d00d9e69cd5eb63f2e69c3a5a59e0cecae5ae14c6ae0b35830fe3b37bad0", size = 4035307 },
+    { url = "https://files.pythonhosted.org/packages/5e/a5/9ec7e81e8526c0d7a387d73386b2daed3f39e10d81a85930bd1b6bfba65c/cryptography-50.0.1-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:05ba322c4da95b262a212c345af888ef2c37c88c0509756ea00a0e6d68850f23", size = 4751900 },
+    { url = "https://files.pythonhosted.org/packages/7e/3c/0e77bd5ffcf078e9dd27d3074aad6c030d9b10d0bf69329d573c927a188c/cryptography-50.0.1-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e22dfed744bd4002e909464cb23d2f0b05c6f3113a79ef2e9864a53db737c733", size = 4738357 },
+    { url = "https://files.pythonhosted.org/packages/27/3a/3c5f80daa4dcd47323c7af8a2fcb90de27a33564d4fcac69846c0972691a/cryptography-50.0.1-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:4c4188f7c0cf655be5c06342b817ed0f9595b69ffa2b12026e5353eed29dea88", size = 4758474 },
+    { url = "https://files.pythonhosted.org/packages/6e/2b/214cf0cf93db9628c3c20c896b229f327f6fb1b20e4b3743d8ad3f00af8b/cryptography-50.0.1-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2ebbfb0f1fed745e91796e3e1080a1440423fdae8ece1b995a1d80883a409054", size = 5375862 },
+    { url = "https://files.pythonhosted.org/packages/d6/51/3f9701867a46b6c1740c9b52fc4d3bed6cbdcfedcc9b6e64305c07f39cff/cryptography-50.0.1-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:407fe2b6db00939c05c0e945e9914238f2f0a430974839429dafc82b1ee6bee5", size = 4772942 },
+    { url = "https://files.pythonhosted.org/packages/0d/5c/13ea642e08e2544d0f5396122055f4820cfacb3203562197b5967125ea97/cryptography-50.0.1-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:2b34d76a652ea2b6faf777c35df230c5637842cd904e04f16230c3f9f03e4361", size = 4383347 },
+    { url = "https://files.pythonhosted.org/packages/84/d5/7d1fe1cb93f91c428093ff234e128c89ba8ea61a6f26aab406081f9b996e/cryptography-50.0.1-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:01f41478cf33fc605a6a089cd56d28b45c6c0b45a1928b61797f2621a04bac71", size = 4758050 },
+    { url = "https://files.pythonhosted.org/packages/dd/04/557fc5ead96a829e0bc812a3b9dc4a52a2f27e4f7f5950da7ff27653a805/cryptography-50.0.1-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:fc3ed7ebd2a8c96f5b166de0ab9b624996bef3b07bbeb19364dfb78222c22c80", size = 5332955 },
+    { url = "https://files.pythonhosted.org/packages/8c/eb/5d7124083e8d8cda8f5b348f544b71ad6f707ad63193758ef4d8e569da02/cryptography-50.0.1-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9dde0a357190eb3b1da1bb9ab750e9c85cba82ca5977aa0836cbb94e92611239", size = 4772694 },
+    { url = "https://files.pythonhosted.org/packages/63/8e/f1f955e0921dd2b6d22eae7e8d24a4c4b638d10735ffbf6a71f99eb0fcb8/cryptography-50.0.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd3718b960d0b5dd213cdf03f3bcb7000e69dda0de8b956061947ff6bcff5558", size = 4888413 },
+    { url = "https://files.pythonhosted.org/packages/1f/ab/89e2b798d2c3925f82e2bb72d5979f3d2f6da2dd22ef4a8cd8b70d920039/cryptography-50.0.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:2a93d05e34d5f67fba6f891fe85d929999baa7195e853923ea6d7576c9e68c5e", size = 5044355 },
+    { url = "https://files.pythonhosted.org/packages/99/89/87ef49ffe383ef4e147d27b7bf2088fb0b54ea409dd87b5a89442e5828a5/cryptography-50.0.1-cp39-abi3-win_amd64.whl", hash = "sha256:55d16b1ef3ee0958d893a977b19777887e546c9954ea81b200c3301a864013f2", size = 3875429 },
+    { url = "https://files.pythonhosted.org/packages/c7/27/8d207af749c453ee17ea087340b3f2b4adef75aadd1d277b1b129bdda84e/cryptography-50.0.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:9cb3cb952cf5a8abd50c782a98a89d71699715e802fe349704b47f2425b42a94", size = 3974350 },
+    { url = "https://files.pythonhosted.org/packages/14/9a/6d3a4d7852e22d657438b7bf51f66102c7d71c0e1fafeec652281d0403e5/cryptography-50.0.1-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:5fe939deeb161024a6be98229c953b6591fef1f41214497a78fe793a244c017f", size = 4698675 },
+    { url = "https://files.pythonhosted.org/packages/73/35/5c3717edf9e68a0550ce04e28eab493fe545eccd81742af03f6a75fe260b/cryptography-50.0.1-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:fb4b9672d389c738b175c4166e78310f8a70358886aacd9173ee03a85ffdc671", size = 4707410 },
+    { url = "https://files.pythonhosted.org/packages/1d/e0/e786934472e3ac4ecdecc7b129a0ca1a2a40dffdafcf2c3ea9d4397f8def/cryptography-50.0.1-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:d63ae8f6481fec907ac0f588eee8a90aefde112c633131fe540e5711ddbb5a4e", size = 4698378 },
+    { url = "https://files.pythonhosted.org/packages/51/cf/5b3f53a0b74d122f023476ede40ba5d3e70d5cf475f73b899740d26a4fb2/cryptography-50.0.1-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:804728ce710890870f3aaa344b2e161172d258d768ac139d02cfd9092d0d94e6", size = 4706889 },
+    { url = "https://files.pythonhosted.org/packages/71/44/711e61f7d014be825ef79b285b047292d1bf893732ac1bc030a351fb517f/cryptography-50.0.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:693c99b49bd37d0d096e4334c10232c77248c415b98d35236094cdf96d57258b", size = 3824006 },
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -213,10 +393,14 @@ wheels = [
 name = "fastapi"
 version = "0.115.8"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "(python_full_version < '3.14' and sys_platform != 'emscripten') or (python_full_version < '3.12' and sys_platform == 'emscripten')",
+]
 dependencies = [
-    { name = "pydantic" },
-    { name = "starlette" },
-    { name = "typing-extensions" },
+    { name = "pydantic", marker = "python_full_version < '3.14'" },
+    { name = "starlette", version = "0.45.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a2/b2/5a5dc4affdb6661dea100324e19a7721d5dc524b464fe8e366c093fd7d87/fastapi-0.115.8.tar.gz", hash = "sha256:0ce9111231720190473e222cdf0f07f7206ad7e53ea02beb1d2dc36e2f0741e9", size = 295403 }
 wheels = [
@@ -224,25 +408,93 @@ wheels = [
 ]
 
 [[package]]
+name = "fastapi"
+version = "0.141.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14'",
+]
+dependencies = [
+    { name = "annotated-doc", marker = "python_full_version >= '3.14'" },
+    { name = "pydantic", marker = "python_full_version >= '3.14'" },
+    { name = "starlette", version = "1.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.14'" },
+    { name = "typing-inspection", marker = "python_full_version >= '3.14'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/02/91e3416a8fdd715abb903a952a6bec7cdd8d14eed55d415fc8595524c319/fastapi-0.141.1.tar.gz", hash = "sha256:e8822fc40db1e1858054d7a949a888695bc9bdce70139178e33bd2871a453ca1", size = 425799 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/03/10388a42375ee7e4ac9b94eb2c5c569c8b5795e377e701c9ac3ad63de890/fastapi-0.141.1-py3-none-any.whl", hash = "sha256:bfb91aa2d334c61cb35ba9a116fc123b3d3df31640b801cf57a7a78ec3f603b3", size = 131954 },
+]
+
+[[package]]
 name = "h11"
 version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+]
 sdist = { url = "https://files.pythonhosted.org/packages/f5/38/3af3d3633a34a3316095b39c8e8fb4853a28a536e55d347bd8d8e9a14b03/h11-0.14.0.tar.gz", hash = "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d", size = 100418 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/95/04/ff642e65ad6b90db43e668d70ffb6736436c7ce41fcc549f4e9472234127/h11-0.14.0-py3-none-any.whl", hash = "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761", size = 58259 },
 ]
 
 [[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "(python_full_version < '3.14' and sys_platform != 'emscripten') or (python_full_version < '3.12' and sys_platform == 'emscripten')",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515 },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.7"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+]
 dependencies = [
-    { name = "certifi" },
-    { name = "h11" },
+    { name = "certifi", marker = "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'" },
+    { name = "h11", version = "0.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6a/41/d7d0a89eb493922c37d343b607bc1b5da7f5be7e383740b4753ad8943e90/httpcore-1.0.7.tar.gz", hash = "sha256:8551cb62a169ec7162ac7be8d4817d561f60e08eaa485234898414bb5a8a0b4c", size = 85196 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/87/f5/72347bc88306acb359581ac4d52f23c0ef445b57157adedb9aee0cd689d2/httpcore-1.0.7-py3-none-any.whl", hash = "sha256:a3fff8f43dc260d5bd363d9f9cf1830fa3a458b332856f34282de498ed420edd", size = 78551 },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "(python_full_version < '3.14' and sys_platform != 'emscripten') or (python_full_version < '3.12' and sys_platform == 'emscripten')",
+]
+dependencies = [
+    { name = "certifi", marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
+    { name = "h11", version = "0.16.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784 },
+]
+
+[[package]]
+name = "httpcore2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11", version = "0.16.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
+    { name = "truststore", marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/74/d370e55600d9bcfa0d9794b0166126d49291a3d2b20c268fc98c453a4948/httpcore2-2.12.0-py3-none-any.whl", hash = "sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb", size = 83074 },
 ]
 
 [[package]]
@@ -252,7 +504,8 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "certifi" },
-    { name = "httpcore" },
+    { name = "httpcore", version = "1.0.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'" },
+    { name = "httpcore", version = "1.0.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
     { name = "idna" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406 }
@@ -261,21 +514,38 @@ wheels = [
 ]
 
 [[package]]
-name = "httpx-sse"
-version = "0.4.0"
+name = "httpx2"
+version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4c/60/8f4281fa9bbf3c8034fd54c0e7412e66edbab6bc74c4996bd616f8d0406e/httpx-sse-0.4.0.tar.gz", hash = "sha256:1e81a3a3070ce322add1d3529ed42eb5f70817f45ed6ec915ab753f961139721", size = 12624 }
+dependencies = [
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "python_full_version >= '3.12' and sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f8/579a8b51e42e38ee32647df9f08aa25643ae788e275cc625b199829c4671/httpx2-2.12.0.tar.gz", hash = "sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf", size = 100040 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/9b/a181f281f65d776426002f330c31849b86b31fc9d848db62e16f03ff739f/httpx_sse-0.4.0-py3-none-any.whl", hash = "sha256:f329af6eae57eaa2bdfd962b42524764af68075ea87370a2de920af5341e318f", size = 7819 },
+    { url = "https://files.pythonhosted.org/packages/c8/95/411ba65569158e862368917aaf56597f3e5fa3b91b0502919638465a08f3/httpx2-2.12.0-py3-none-any.whl", hash = "sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36", size = 95427 },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382 },
 ]
 
 [[package]]
 name = "idna"
-version = "3.10"
+version = "3.19"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490 }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz", hash = "sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15", size = 215237 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442 },
+    { url = "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl", hash = "sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4", size = 68550 },
 ]
 
 [[package]]
@@ -382,21 +652,29 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.2.1"
+version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
+    { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
-    { name = "sse-starlette" },
-    { name = "starlette" },
-    { name = "uvicorn" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "sse-starlette", version = "3.4.11", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "starlette", version = "0.45.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "starlette", version = "1.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/30/51e4555826126e3954fa2ab1e934bf74163c5fe05e98f38ca4d0f8abbf63/mcp-1.2.1.tar.gz", hash = "sha256:c9d43dbfe943aa1530e2be8f54b73af3ebfb071243827b4483d421684806cb45", size = 103968 }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/6e/21fb8e5d579dbe21d96ea4d5034200d46d8bdf2261053b5bd041f3c2f612/mcp-2.1.1.tar.gz", hash = "sha256:50b7ba1ebbe117008ea7bdd288234043e69c20b403d6851d19661e6d431a75ef", size = 3984589 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4c/0d/6770742a84c8aa1d36c0d628896a380584c5759612e66af7446af07d8775/mcp-1.2.1-py3-none-any.whl", hash = "sha256:579bf9c9157850ebb1344f3ca6f7a3021b0123c44c9f089ef577a7062522f0fd", size = 66453 },
+    { url = "https://files.pythonhosted.org/packages/50/af/8644cc5fa26a59afd2df2e98eeb19e72926887fa4b7441aba4ff661140db/mcp-2.1.1-py3-none-any.whl", hash = "sha256:1c6c31c5d6471c58db76af3af8af67f46d11d01f0a59077d0a308cbdb3d3e915", size = 357912 },
 ]
 
 [package.optional-dependencies]
@@ -407,10 +685,11 @@ cli = [
 
 [[package]]
 name = "mcp-openapi-proxy"
-version = "0.3.4"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
-    { name = "fastapi" },
+    { name = "fastapi", version = "0.115.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "fastapi", version = "0.141.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "jmespath" },
     { name = "mcp", extra = ["cli"] },
     { name = "openapi-spec-validator" },
@@ -418,10 +697,13 @@ dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "requests" },
+    { name = "uvicorn" },
 ]
 
 [package.optional-dependencies]
 dev = [
+    { name = "httpx" },
+    { name = "packaging" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -430,18 +712,34 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fastapi", specifier = ">=0.100.0" },
+    { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0" },
     { name = "jmespath", specifier = ">=1.0.1" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.2.0,<2" },
+    { name = "mcp", extras = ["cli"], specifier = ">=2.0.0,<3" },
     { name = "openapi-spec-validator", specifier = ">=0.7.1" },
+    { name = "packaging", marker = "extra == 'dev'", specifier = ">=24.0" },
     { name = "prance", specifier = ">=23.6.21.0" },
-    { name = "pydantic", specifier = ">=2.0" },
+    { name = "pydantic", specifier = ">=2.12" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.4" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "requests", specifier = ">=2.25.0" },
+    { name = "uvicorn", specifier = ">=0.32.0" },
 ]
 provides-extras = ["dev"]
+
+[[package]]
+name = "mcp-types"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/dd/1c4417dc0b722c23a1669032d5f044e41170fe5d4773b488a50fcce98c32/mcp_types-2.1.1.tar.gz", hash = "sha256:77dcbe48fba73cca71a673f2646a5f037a017b7a0a07ac89cec1113028890eda", size = 66674 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/d0/242e63c510f4a17381f55b1549a3f94f5687a0595984febd2b6f87a687a0/mcp_types-2.1.1-py3-none-any.whl", hash = "sha256:26f9f7f03f2a5730717a5b98e2ab7eb640ac352d05a00cdc725c311864778295", size = 69656 },
+]
 
 [[package]]
 name = "mdurl"
@@ -479,6 +777,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/67/fe/21954ff978239dc29ebb313f5c87eeb4ec929b694b9667323086730998e2/openapi_spec_validator-0.7.1.tar.gz", hash = "sha256:8577b85a8268685da6f8aa30990b83b7960d4d1117e901d451b5d572605e5ec7", size = 37985 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2b/4d/e744fff95aaf3aeafc968d5ba7297c8cda0d1ecb8e3acd21b25adae4d835/openapi_spec_validator-0.7.1-py3-none-any.whl", hash = "sha256:3c81825043f24ccbcd2f4b149b11e8231abce5ba84f37065e14ec947d8f4e959", size = 38998 },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018 },
 ]
 
 [[package]]
@@ -525,105 +835,135 @@ wheels = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172 },
+]
+
+[[package]]
 name = "pydantic"
-version = "2.10.6"
+version = "2.13.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
     { name = "pydantic-core" },
     { name = "typing-extensions" },
+    { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b7/ae/d5220c5c52b158b1de7ca89fc5edb72f304a70a4c540c84c8844bf4008de/pydantic-2.10.6.tar.gz", hash = "sha256:ca5daa827cce33de7a42be142548b0096bf05a7e7b365aebfa5f8eeec7128236", size = 761681 }
+sdist = { url = "https://files.pythonhosted.org/packages/53/ef/fc4f868f4e2cee79f863883abffceff107875f569b848507319842d2a681/pydantic-2.13.5.tar.gz", hash = "sha256:51a9c5f7b2f8e636f04c6cada605d9b6a3bf1348fdf945a3d8869b19bba0ee08", size = 845750 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/3c/8cc1cc84deffa6e25d2d0c688ebb80635dfdbf1dbea3e30c541c8cf4d860/pydantic-2.10.6-py3-none-any.whl", hash = "sha256:427d664bf0b8a2b34ff5dd0f5a18df00591adcee7198fbd71981054cef37b584", size = 431696 },
+    { url = "https://files.pythonhosted.org/packages/eb/47/c95ffc2009878c7aac0c5e08528022dcb885933252a88b5f170058014464/pydantic-2.13.5-py3-none-any.whl", hash = "sha256:346a034f080da3755d8e9cb5e00e8b07de1d39e4f6e2c87d8ab7cafa0b269a73", size = 472589 },
 ]
 
 [[package]]
 name = "pydantic-core"
-version = "2.27.2"
+version = "2.46.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/01/f3e5ac5e7c25833db5eb555f7b7ab24cd6f8c322d3a3ad2d67a952dc0abc/pydantic_core-2.27.2.tar.gz", hash = "sha256:eb026e5a4c1fee05726072337ff51d1efb6f59090b7da90d30ea58625b1ffb39", size = 413443 }
+sdist = { url = "https://files.pythonhosted.org/packages/af/f9/8a06bea35ef8daf588f707784c973a7046e0034c8d8cfb08828eeffb8b75/pydantic_core-2.46.5.tar.gz", hash = "sha256:10416c15b8839ecc4ef4d0885da76da6fd0f67333a0eb8aff6d93c4b8f2910fc", size = 472262 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/bc/fed5f74b5d802cf9a03e83f60f18864e90e3aed7223adaca5ffb7a8d8d64/pydantic_core-2.27.2-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:2d367ca20b2f14095a8f4fa1210f5a7b78b8a20009ecced6b12818f455b1e9fa", size = 1895938 },
-    { url = "https://files.pythonhosted.org/packages/71/2a/185aff24ce844e39abb8dd680f4e959f0006944f4a8a0ea372d9f9ae2e53/pydantic_core-2.27.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:491a2b73db93fab69731eaee494f320faa4e093dbed776be1a829c2eb222c34c", size = 1815684 },
-    { url = "https://files.pythonhosted.org/packages/c3/43/fafabd3d94d159d4f1ed62e383e264f146a17dd4d48453319fd782e7979e/pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7969e133a6f183be60e9f6f56bfae753585680f3b7307a8e555a948d443cc05a", size = 1829169 },
-    { url = "https://files.pythonhosted.org/packages/a2/d1/f2dfe1a2a637ce6800b799aa086d079998959f6f1215eb4497966efd2274/pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3de9961f2a346257caf0aa508a4da705467f53778e9ef6fe744c038119737ef5", size = 1867227 },
-    { url = "https://files.pythonhosted.org/packages/7d/39/e06fcbcc1c785daa3160ccf6c1c38fea31f5754b756e34b65f74e99780b5/pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e2bb4d3e5873c37bb3dd58714d4cd0b0e6238cebc4177ac8fe878f8b3aa8e74c", size = 2037695 },
-    { url = "https://files.pythonhosted.org/packages/7a/67/61291ee98e07f0650eb756d44998214231f50751ba7e13f4f325d95249ab/pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:280d219beebb0752699480fe8f1dc61ab6615c2046d76b7ab7ee38858de0a4e7", size = 2741662 },
-    { url = "https://files.pythonhosted.org/packages/32/90/3b15e31b88ca39e9e626630b4c4a1f5a0dfd09076366f4219429e6786076/pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47956ae78b6422cbd46f772f1746799cbb862de838fd8d1fbd34a82e05b0983a", size = 1993370 },
-    { url = "https://files.pythonhosted.org/packages/ff/83/c06d333ee3a67e2e13e07794995c1535565132940715931c1c43bfc85b11/pydantic_core-2.27.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:14d4a5c49d2f009d62a2a7140d3064f686d17a5d1a268bc641954ba181880236", size = 1996813 },
-    { url = "https://files.pythonhosted.org/packages/7c/f7/89be1c8deb6e22618a74f0ca0d933fdcb8baa254753b26b25ad3acff8f74/pydantic_core-2.27.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:337b443af21d488716f8d0b6164de833e788aa6bd7e3a39c005febc1284f4962", size = 2005287 },
-    { url = "https://files.pythonhosted.org/packages/b7/7d/8eb3e23206c00ef7feee17b83a4ffa0a623eb1a9d382e56e4aa46fd15ff2/pydantic_core-2.27.2-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:03d0f86ea3184a12f41a2d23f7ccb79cdb5a18e06993f8a45baa8dfec746f0e9", size = 2128414 },
-    { url = "https://files.pythonhosted.org/packages/4e/99/fe80f3ff8dd71a3ea15763878d464476e6cb0a2db95ff1c5c554133b6b83/pydantic_core-2.27.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:7041c36f5680c6e0f08d922aed302e98b3745d97fe1589db0a3eebf6624523af", size = 2155301 },
-    { url = "https://files.pythonhosted.org/packages/2b/a3/e50460b9a5789ca1451b70d4f52546fa9e2b420ba3bfa6100105c0559238/pydantic_core-2.27.2-cp310-cp310-win32.whl", hash = "sha256:50a68f3e3819077be2c98110c1f9dcb3817e93f267ba80a2c05bb4f8799e2ff4", size = 1816685 },
-    { url = "https://files.pythonhosted.org/packages/57/4c/a8838731cb0f2c2a39d3535376466de6049034d7b239c0202a64aaa05533/pydantic_core-2.27.2-cp310-cp310-win_amd64.whl", hash = "sha256:e0fd26b16394ead34a424eecf8a31a1f5137094cabe84a1bcb10fa6ba39d3d31", size = 1982876 },
-    { url = "https://files.pythonhosted.org/packages/c2/89/f3450af9d09d44eea1f2c369f49e8f181d742f28220f88cc4dfaae91ea6e/pydantic_core-2.27.2-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:8e10c99ef58cfdf2a66fc15d66b16c4a04f62bca39db589ae8cba08bc55331bc", size = 1893421 },
-    { url = "https://files.pythonhosted.org/packages/9e/e3/71fe85af2021f3f386da42d291412e5baf6ce7716bd7101ea49c810eda90/pydantic_core-2.27.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:26f32e0adf166a84d0cb63be85c562ca8a6fa8de28e5f0d92250c6b7e9e2aff7", size = 1814998 },
-    { url = "https://files.pythonhosted.org/packages/a6/3c/724039e0d848fd69dbf5806894e26479577316c6f0f112bacaf67aa889ac/pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c19d1ea0673cd13cc2f872f6c9ab42acc4e4f492a7ca9d3795ce2b112dd7e15", size = 1826167 },
-    { url = "https://files.pythonhosted.org/packages/2b/5b/1b29e8c1fb5f3199a9a57c1452004ff39f494bbe9bdbe9a81e18172e40d3/pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5e68c4446fe0810e959cdff46ab0a41ce2f2c86d227d96dc3847af0ba7def306", size = 1865071 },
-    { url = "https://files.pythonhosted.org/packages/89/6c/3985203863d76bb7d7266e36970d7e3b6385148c18a68cc8915fd8c84d57/pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d9640b0059ff4f14d1f37321b94061c6db164fbe49b334b31643e0528d100d99", size = 2036244 },
-    { url = "https://files.pythonhosted.org/packages/0e/41/f15316858a246b5d723f7d7f599f79e37493b2e84bfc789e58d88c209f8a/pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:40d02e7d45c9f8af700f3452f329ead92da4c5f4317ca9b896de7ce7199ea459", size = 2737470 },
-    { url = "https://files.pythonhosted.org/packages/a8/7c/b860618c25678bbd6d1d99dbdfdf0510ccb50790099b963ff78a124b754f/pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1c1fd185014191700554795c99b347d64f2bb637966c4cfc16998a0ca700d048", size = 1992291 },
-    { url = "https://files.pythonhosted.org/packages/bf/73/42c3742a391eccbeab39f15213ecda3104ae8682ba3c0c28069fbcb8c10d/pydantic_core-2.27.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d81d2068e1c1228a565af076598f9e7451712700b673de8f502f0334f281387d", size = 1994613 },
-    { url = "https://files.pythonhosted.org/packages/94/7a/941e89096d1175d56f59340f3a8ebaf20762fef222c298ea96d36a6328c5/pydantic_core-2.27.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1a4207639fb02ec2dbb76227d7c751a20b1a6b4bc52850568e52260cae64ca3b", size = 2002355 },
-    { url = "https://files.pythonhosted.org/packages/6e/95/2359937a73d49e336a5a19848713555605d4d8d6940c3ec6c6c0ca4dcf25/pydantic_core-2.27.2-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:3de3ce3c9ddc8bbd88f6e0e304dea0e66d843ec9de1b0042b0911c1663ffd474", size = 2126661 },
-    { url = "https://files.pythonhosted.org/packages/2b/4c/ca02b7bdb6012a1adef21a50625b14f43ed4d11f1fc237f9d7490aa5078c/pydantic_core-2.27.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:30c5f68ded0c36466acede341551106821043e9afaad516adfb6e8fa80a4e6a6", size = 2153261 },
-    { url = "https://files.pythonhosted.org/packages/72/9d/a241db83f973049a1092a079272ffe2e3e82e98561ef6214ab53fe53b1c7/pydantic_core-2.27.2-cp311-cp311-win32.whl", hash = "sha256:c70c26d2c99f78b125a3459f8afe1aed4d9687c24fd677c6a4436bc042e50d6c", size = 1812361 },
-    { url = "https://files.pythonhosted.org/packages/e8/ef/013f07248041b74abd48a385e2110aa3a9bbfef0fbd97d4e6d07d2f5b89a/pydantic_core-2.27.2-cp311-cp311-win_amd64.whl", hash = "sha256:08e125dbdc505fa69ca7d9c499639ab6407cfa909214d500897d02afb816e7cc", size = 1982484 },
-    { url = "https://files.pythonhosted.org/packages/10/1c/16b3a3e3398fd29dca77cea0a1d998d6bde3902fa2706985191e2313cc76/pydantic_core-2.27.2-cp311-cp311-win_arm64.whl", hash = "sha256:26f0d68d4b235a2bae0c3fc585c585b4ecc51382db0e3ba402a22cbc440915e4", size = 1867102 },
-    { url = "https://files.pythonhosted.org/packages/d6/74/51c8a5482ca447871c93e142d9d4a92ead74de6c8dc5e66733e22c9bba89/pydantic_core-2.27.2-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:9e0c8cfefa0ef83b4da9588448b6d8d2a2bf1a53c3f1ae5fca39eb3061e2f0b0", size = 1893127 },
-    { url = "https://files.pythonhosted.org/packages/d3/f3/c97e80721735868313c58b89d2de85fa80fe8dfeeed84dc51598b92a135e/pydantic_core-2.27.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:83097677b8e3bd7eaa6775720ec8e0405f1575015a463285a92bfdfe254529ef", size = 1811340 },
-    { url = "https://files.pythonhosted.org/packages/9e/91/840ec1375e686dbae1bd80a9e46c26a1e0083e1186abc610efa3d9a36180/pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:172fce187655fece0c90d90a678424b013f8fbb0ca8b036ac266749c09438cb7", size = 1822900 },
-    { url = "https://files.pythonhosted.org/packages/f6/31/4240bc96025035500c18adc149aa6ffdf1a0062a4b525c932065ceb4d868/pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:519f29f5213271eeeeb3093f662ba2fd512b91c5f188f3bb7b27bc5973816934", size = 1869177 },
-    { url = "https://files.pythonhosted.org/packages/fa/20/02fbaadb7808be578317015c462655c317a77a7c8f0ef274bc016a784c54/pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:05e3a55d124407fffba0dd6b0c0cd056d10e983ceb4e5dbd10dda135c31071d6", size = 2038046 },
-    { url = "https://files.pythonhosted.org/packages/06/86/7f306b904e6c9eccf0668248b3f272090e49c275bc488a7b88b0823444a4/pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9c3ed807c7b91de05e63930188f19e921d1fe90de6b4f5cd43ee7fcc3525cb8c", size = 2685386 },
-    { url = "https://files.pythonhosted.org/packages/8d/f0/49129b27c43396581a635d8710dae54a791b17dfc50c70164866bbf865e3/pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6fb4aadc0b9a0c063206846d603b92030eb6f03069151a625667f982887153e2", size = 1997060 },
-    { url = "https://files.pythonhosted.org/packages/0d/0f/943b4af7cd416c477fd40b187036c4f89b416a33d3cc0ab7b82708a667aa/pydantic_core-2.27.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:28ccb213807e037460326424ceb8b5245acb88f32f3d2777427476e1b32c48c4", size = 2004870 },
-    { url = "https://files.pythonhosted.org/packages/35/40/aea70b5b1a63911c53a4c8117c0a828d6790483f858041f47bab0b779f44/pydantic_core-2.27.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:de3cd1899e2c279b140adde9357c4495ed9d47131b4a4eaff9052f23398076b3", size = 1999822 },
-    { url = "https://files.pythonhosted.org/packages/f2/b3/807b94fd337d58effc5498fd1a7a4d9d59af4133e83e32ae39a96fddec9d/pydantic_core-2.27.2-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:220f892729375e2d736b97d0e51466252ad84c51857d4d15f5e9692f9ef12be4", size = 2130364 },
-    { url = "https://files.pythonhosted.org/packages/fc/df/791c827cd4ee6efd59248dca9369fb35e80a9484462c33c6649a8d02b565/pydantic_core-2.27.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:a0fcd29cd6b4e74fe8ddd2c90330fd8edf2e30cb52acda47f06dd615ae72da57", size = 2158303 },
-    { url = "https://files.pythonhosted.org/packages/9b/67/4e197c300976af185b7cef4c02203e175fb127e414125916bf1128b639a9/pydantic_core-2.27.2-cp312-cp312-win32.whl", hash = "sha256:1e2cb691ed9834cd6a8be61228471d0a503731abfb42f82458ff27be7b2186fc", size = 1834064 },
-    { url = "https://files.pythonhosted.org/packages/1f/ea/cd7209a889163b8dcca139fe32b9687dd05249161a3edda62860430457a5/pydantic_core-2.27.2-cp312-cp312-win_amd64.whl", hash = "sha256:cc3f1a99a4f4f9dd1de4fe0312c114e740b5ddead65bb4102884b384c15d8bc9", size = 1989046 },
-    { url = "https://files.pythonhosted.org/packages/bc/49/c54baab2f4658c26ac633d798dab66b4c3a9bbf47cff5284e9c182f4137a/pydantic_core-2.27.2-cp312-cp312-win_arm64.whl", hash = "sha256:3911ac9284cd8a1792d3cb26a2da18f3ca26c6908cc434a18f730dc0db7bfa3b", size = 1885092 },
-    { url = "https://files.pythonhosted.org/packages/41/b1/9bc383f48f8002f99104e3acff6cba1231b29ef76cfa45d1506a5cad1f84/pydantic_core-2.27.2-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:7d14bd329640e63852364c306f4d23eb744e0f8193148d4044dd3dacdaacbd8b", size = 1892709 },
-    { url = "https://files.pythonhosted.org/packages/10/6c/e62b8657b834f3eb2961b49ec8e301eb99946245e70bf42c8817350cbefc/pydantic_core-2.27.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:82f91663004eb8ed30ff478d77c4d1179b3563df6cdb15c0817cd1cdaf34d154", size = 1811273 },
-    { url = "https://files.pythonhosted.org/packages/ba/15/52cfe49c8c986e081b863b102d6b859d9defc63446b642ccbbb3742bf371/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:71b24c7d61131bb83df10cc7e687433609963a944ccf45190cfc21e0887b08c9", size = 1823027 },
-    { url = "https://files.pythonhosted.org/packages/b1/1c/b6f402cfc18ec0024120602bdbcebc7bdd5b856528c013bd4d13865ca473/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fa8e459d4954f608fa26116118bb67f56b93b209c39b008277ace29937453dc9", size = 1868888 },
-    { url = "https://files.pythonhosted.org/packages/bd/7b/8cb75b66ac37bc2975a3b7de99f3c6f355fcc4d89820b61dffa8f1e81677/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ce8918cbebc8da707ba805b7fd0b382816858728ae7fe19a942080c24e5b7cd1", size = 2037738 },
-    { url = "https://files.pythonhosted.org/packages/c8/f1/786d8fe78970a06f61df22cba58e365ce304bf9b9f46cc71c8c424e0c334/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eda3f5c2a021bbc5d976107bb302e0131351c2ba54343f8a496dc8783d3d3a6a", size = 2685138 },
-    { url = "https://files.pythonhosted.org/packages/a6/74/d12b2cd841d8724dc8ffb13fc5cef86566a53ed358103150209ecd5d1999/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bd8086fa684c4775c27f03f062cbb9eaa6e17f064307e86b21b9e0abc9c0f02e", size = 1997025 },
-    { url = "https://files.pythonhosted.org/packages/a0/6e/940bcd631bc4d9a06c9539b51f070b66e8f370ed0933f392db6ff350d873/pydantic_core-2.27.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8d9b3388db186ba0c099a6d20f0604a44eabdeef1777ddd94786cdae158729e4", size = 2004633 },
-    { url = "https://files.pythonhosted.org/packages/50/cc/a46b34f1708d82498c227d5d80ce615b2dd502ddcfd8376fc14a36655af1/pydantic_core-2.27.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:7a66efda2387de898c8f38c0cf7f14fca0b51a8ef0b24bfea5849f1b3c95af27", size = 1999404 },
-    { url = "https://files.pythonhosted.org/packages/ca/2d/c365cfa930ed23bc58c41463bae347d1005537dc8db79e998af8ba28d35e/pydantic_core-2.27.2-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:18a101c168e4e092ab40dbc2503bdc0f62010e95d292b27827871dc85450d7ee", size = 2130130 },
-    { url = "https://files.pythonhosted.org/packages/f4/d7/eb64d015c350b7cdb371145b54d96c919d4db516817f31cd1c650cae3b21/pydantic_core-2.27.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ba5dd002f88b78a4215ed2f8ddbdf85e8513382820ba15ad5ad8955ce0ca19a1", size = 2157946 },
-    { url = "https://files.pythonhosted.org/packages/a4/99/bddde3ddde76c03b65dfd5a66ab436c4e58ffc42927d4ff1198ffbf96f5f/pydantic_core-2.27.2-cp313-cp313-win32.whl", hash = "sha256:1ebaf1d0481914d004a573394f4be3a7616334be70261007e47c2a6fe7e50130", size = 1834387 },
-    { url = "https://files.pythonhosted.org/packages/71/47/82b5e846e01b26ac6f1893d3c5f9f3a2eb6ba79be26eef0b759b4fe72946/pydantic_core-2.27.2-cp313-cp313-win_amd64.whl", hash = "sha256:953101387ecf2f5652883208769a79e48db18c6df442568a0b5ccd8c2723abee", size = 1990453 },
-    { url = "https://files.pythonhosted.org/packages/51/b2/b2b50d5ecf21acf870190ae5d093602d95f66c9c31f9d5de6062eb329ad1/pydantic_core-2.27.2-cp313-cp313-win_arm64.whl", hash = "sha256:ac4dbfd1691affb8f48c2c13241a2e3b60ff23247cbcf981759c768b6633cf8b", size = 1885186 },
-    { url = "https://files.pythonhosted.org/packages/46/72/af70981a341500419e67d5cb45abe552a7c74b66326ac8877588488da1ac/pydantic_core-2.27.2-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:2bf14caea37e91198329b828eae1618c068dfb8ef17bb33287a7ad4b61ac314e", size = 1891159 },
-    { url = "https://files.pythonhosted.org/packages/ad/3d/c5913cccdef93e0a6a95c2d057d2c2cba347815c845cda79ddd3c0f5e17d/pydantic_core-2.27.2-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:b0cb791f5b45307caae8810c2023a184c74605ec3bcbb67d13846c28ff731ff8", size = 1768331 },
-    { url = "https://files.pythonhosted.org/packages/f6/f0/a3ae8fbee269e4934f14e2e0e00928f9346c5943174f2811193113e58252/pydantic_core-2.27.2-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:688d3fd9fcb71f41c4c015c023d12a79d1c4c0732ec9eb35d96e3388a120dcf3", size = 1822467 },
-    { url = "https://files.pythonhosted.org/packages/d7/7a/7bbf241a04e9f9ea24cd5874354a83526d639b02674648af3f350554276c/pydantic_core-2.27.2-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3d591580c34f4d731592f0e9fe40f9cc1b430d297eecc70b962e93c5c668f15f", size = 1979797 },
-    { url = "https://files.pythonhosted.org/packages/4f/5f/4784c6107731f89e0005a92ecb8a2efeafdb55eb992b8e9d0a2be5199335/pydantic_core-2.27.2-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:82f986faf4e644ffc189a7f1aafc86e46ef70372bb153e7001e8afccc6e54133", size = 1987839 },
-    { url = "https://files.pythonhosted.org/packages/6d/a7/61246562b651dff00de86a5f01b6e4befb518df314c54dec187a78d81c84/pydantic_core-2.27.2-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:bec317a27290e2537f922639cafd54990551725fc844249e64c523301d0822fc", size = 1998861 },
-    { url = "https://files.pythonhosted.org/packages/86/aa/837821ecf0c022bbb74ca132e117c358321e72e7f9702d1b6a03758545e2/pydantic_core-2.27.2-pp310-pypy310_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:0296abcb83a797db256b773f45773da397da75a08f5fcaef41f2044adec05f50", size = 2116582 },
-    { url = "https://files.pythonhosted.org/packages/81/b0/5e74656e95623cbaa0a6278d16cf15e10a51f6002e3ec126541e95c29ea3/pydantic_core-2.27.2-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:0d75070718e369e452075a6017fbf187f788e17ed67a3abd47fa934d001863d9", size = 2151985 },
-    { url = "https://files.pythonhosted.org/packages/63/37/3e32eeb2a451fddaa3898e2163746b0cffbbdbb4740d38372db0490d67f3/pydantic_core-2.27.2-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:7e17b560be3c98a8e3aa66ce828bdebb9e9ac6ad5466fba92eb74c4c95cb1151", size = 2004715 },
-]
-
-[[package]]
-name = "pydantic-settings"
-version = "2.7.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/73/7b/c58a586cd7d9ac66d2ee4ba60ca2d241fa837c02bca9bea80a9a8c3d22a9/pydantic_settings-2.7.1.tar.gz", hash = "sha256:10c9caad35e64bfb3c2fbf70a078c0e25cc92499782e5200747f942a065dec93", size = 79920 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b4/46/93416fdae86d40879714f72956ac14df9c7b76f7d41a4d68aa9f71a0028b/pydantic_settings-2.7.1-py3-none-any.whl", hash = "sha256:590be9e6e24d06db33a4262829edef682500ef008565a969c73d39d5f8bfb3fd", size = 29718 },
+    { url = "https://files.pythonhosted.org/packages/74/6b/8f79692844269427abb3e4dd9e68edfcbe65ae25527d99183214de716c59/pydantic_core-2.46.5-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:657b40d6240c0a7b6a64b30f22d1e3aa631c7e846c621b0c0f6d1d75e2e15ea6", size = 2076533 },
+    { url = "https://files.pythonhosted.org/packages/bd/d0/c787604c71c2bdcda1a5656942fc822cd0f9cd879b9484bb84fc42172703/pydantic_core-2.46.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ecb42011e12ee19cafbc312887cbf3546959fe02fbad44f272d4be5baa997615", size = 1924650 },
+    { url = "https://files.pythonhosted.org/packages/4a/77/ca2f8e997d9bfdb32205297aff38f210f398822d895b1af1b59fd9df9c13/pydantic_core-2.46.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4dedce55295becb61921e386b99d4f2706045306e7fa52249a33004c837379fb", size = 1951261 },
+    { url = "https://files.pythonhosted.org/packages/a0/53/bd12e1a9255df4edee00353778e2614b5346265d51e1567ab72153e803a2/pydantic_core-2.46.5-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9f47b8a949e60f027f0aa0a6f6c7b7e9c55cbf4380d10b344e282fa4e7ab1e1b", size = 2021808 },
+    { url = "https://files.pythonhosted.org/packages/d7/41/f7f312751ebc6d6767da91964a9c7954c18e226a1720ab234e3dfb9d6c17/pydantic_core-2.46.5-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:200aa3dc9f8d54f0754f43247c0bad0999fdcfbfd2488384dd44f37279271fe6", size = 2196184 },
+    { url = "https://files.pythonhosted.org/packages/3d/93/ce93aa030ab6bac4683ba8861e7baad89dd24b02e66b8801a0e4f6a00311/pydantic_core-2.46.5-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6d30e1a4f138b8951063e9a394752a9179b51da288ffa507b1e659222f4c1793", size = 2238212 },
+    { url = "https://files.pythonhosted.org/packages/34/a1/c8e6b66f499f510752c07a092dfe27621f9c255635e59d38704b5681c35a/pydantic_core-2.46.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:850a08d167dde16db8702c274f320c7be9d7da6f6dff2b58b18f9e815bd94f5b", size = 2064073 },
+    { url = "https://files.pythonhosted.org/packages/5c/fa/605e2b127ee30dbf4b1da9da4843587cf2b2d16486c241cc7a5be2d2c1bd/pydantic_core-2.46.5-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:c3471e5c4a949c26ec00a77f01df59096aa9495877de76fd60a980f8ee6be461", size = 2093102 },
+    { url = "https://files.pythonhosted.org/packages/4a/f7/1ab28093c09032ddce7c92c7a55d503b6ecd70f42c32492946c1cb5477b1/pydantic_core-2.46.5-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:3a3e26b6a8274211bddee2d0e4d0d42778f17a34510f49d2ec44b58abfc41736", size = 2133452 },
+    { url = "https://files.pythonhosted.org/packages/30/c8/47c79b756f12f85e8b0fbdb2b495f6b6eb32e6c98a4beae7a570a0b7c63c/pydantic_core-2.46.5-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:fc5d783bd4a2387e97b8a2d5ec781cfb92b3d893bf82370548e99db5915935d3", size = 2146477 },
+    { url = "https://files.pythonhosted.org/packages/13/5c/79fc00cb8f651d6061991de8d7cedf1c78c73cbd4862c42ef418f03b8bfa/pydantic_core-2.46.5-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:356c8368cbc321050b169595683a2e1d63413b1e0e2868b330af9fc14c616d3f", size = 2300832 },
+    { url = "https://files.pythonhosted.org/packages/b4/72/dd1a29853cf6d22a1ebd9e3baf0239cbc57d2d16caff36a89e38eb9b1db3/pydantic_core-2.46.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:eb7d8d0e5886a89a55d2eef490e272fa965a9d57c6b29a5b5088a7997ec2cad1", size = 2320505 },
+    { url = "https://files.pythonhosted.org/packages/ec/d1/ba4a8e06a9ddad0b4caf69cfaeecc0fbfcec20473bd808f5127fd16491c4/pydantic_core-2.46.5-cp310-cp310-win32.whl", hash = "sha256:4d44cf99ddebf875f9b68cc267aa684c99b7b44fe63ee1cac4ec163807290069", size = 1956853 },
+    { url = "https://files.pythonhosted.org/packages/f2/94/205ed9d7ddaf44acd489889708ea124a3f41bdb42c141c8684d528ad0e7a/pydantic_core-2.46.5-cp310-cp310-win_amd64.whl", hash = "sha256:1e5aad1220a1192c42341c8fd4a8686657e73ab2a920c970bdc4de334fe3193d", size = 2042551 },
+    { url = "https://files.pythonhosted.org/packages/a2/b6/81d2d19ea0be2c03664381b59f65fa72fc7969decedae00bc2c4ad835708/pydantic_core-2.46.5-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a1dee1b804ff4d11c663636cf15d2ea47e9f79cd56c033fb1cbf08924842a48f", size = 2074737 },
+    { url = "https://files.pythonhosted.org/packages/0c/18/b70da8300e292df4099684ea11b1958043580d2f50d2dc8bf7e542bdd84a/pydantic_core-2.46.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d625a186a65201c23a9e3b8ed9c47e90a026e03256608cc91851c6709096844f", size = 1921751 },
+    { url = "https://files.pythonhosted.org/packages/e7/1a/0d590341b6ffa4b4aca83508e6b8db4761aaeacfc15a25ca3815876d4797/pydantic_core-2.46.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f8507560a9284e1370bb048ed4282012fbef4e8d109875b95e884d228552061", size = 1948231 },
+    { url = "https://files.pythonhosted.org/packages/7d/1d/02eb35761c51f2f7b1b042d6ab4cda6600f0c8c88a2243b3f734376201e5/pydantic_core-2.46.5-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5f93c5fe914d75fbec9a49209b00da5f08e9e467d69da2b1510c81940cfd10be", size = 2020708 },
+    { url = "https://files.pythonhosted.org/packages/4a/ea/f86073830e35d508cc8ddf9c3d9e6e6840fcb88d34bf726b0b4710186f27/pydantic_core-2.46.5-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aca6c767f552b21b10f774aeac128e828eafb796adfa1b666a18bf6321453c3a", size = 2194914 },
+    { url = "https://files.pythonhosted.org/packages/bb/d7/fc36240d7791ce90939e51608568c33bfdae26202016f9770c229a487d86/pydantic_core-2.46.5-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:701b2e04b560eeb4bddf7a25ab8ca476176e34fdbd9a0e18196f0d12d4685f0b", size = 2235622 },
+    { url = "https://files.pythonhosted.org/packages/cf/bc/3fa2d76b83162820a17da7f645b28d1cba99fc8e1e5fc6517067ec450fa1/pydantic_core-2.46.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49776eab08766a08dfff7012f8b422dcd7e25e43b316eedf0477c24fcfa84b7c", size = 2062091 },
+    { url = "https://files.pythonhosted.org/packages/ab/9a/095d557bb492c90cd8a70a6dd048bf793d433d03d86c81c11e912e4cd049/pydantic_core-2.46.5-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:a2468d93d181667a7abd66e1b64bb9f76f361b0fef8faddf687456453576f5ee", size = 2089904 },
+    { url = "https://files.pythonhosted.org/packages/24/98/7b76b1ad10a19a617a52aaa1d80e159115af939b095e86f8e756fd52e0df/pydantic_core-2.46.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:53feb344243bb9510a9dec7bf3cf1b64d88a98af5dc7872a5160465f8b198c8e", size = 2132244 },
+    { url = "https://files.pythonhosted.org/packages/20/32/7d6ca365fadba186a0c8f85de1a701663bce81efd309d9479be58687622f/pydantic_core-2.46.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:cd5214352ae68f3b5e9af7768bdc5253695ee069675db3480518420b3be881f2", size = 2143901 },
+    { url = "https://files.pythonhosted.org/packages/f8/09/eb9a6aa57f22fd1541a9c0aa2a1f3aeef3ec65347d33e10a6da2f43e0ee9/pydantic_core-2.46.5-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:9432f3598db432cb51c5b37fdbf29a60fcccc79e30d37a05022776a6bc4ab689", size = 2299425 },
+    { url = "https://files.pythonhosted.org/packages/8a/f9/548a5bb9d4ba8cd26e26daf48052236f6b38bb61e7b7241fbc3c995719eb/pydantic_core-2.46.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:8feeac04b5794e513e710af2f9c87d49f31a6dc47967bb264a1fed61a8989bec", size = 2318566 },
+    { url = "https://files.pythonhosted.org/packages/4a/20/06454d18834c02c406c9133f1a3b485305fd9ee984f9636c2f730bef6a9d/pydantic_core-2.46.5-cp311-cp311-win32.whl", hash = "sha256:892a881d5f68c2b9ea304b7a6c2c60d9343df578a311b0f86b94bc8f1ffe8129", size = 1954258 },
+    { url = "https://files.pythonhosted.org/packages/9e/c2/718b9deb4b72453b5d8c7447a3b14cb77bef36917ef5f514e0948a4096a0/pydantic_core-2.46.5-cp311-cp311-win_amd64.whl", hash = "sha256:40375c2d05acec10323e45dfe2077ac44bc74659008614af5069034e2cfc781c", size = 2041030 },
+    { url = "https://files.pythonhosted.org/packages/67/ea/c1d1a5b72d6e1ff7f377a4d9199f6591f095beb5b409a8a5d89f7238d939/pydantic_core-2.46.5-cp311-cp311-win_arm64.whl", hash = "sha256:28a6a556cd3b6066bea827857f9d9cce027c96f776e512f544a581f9e42161f8", size = 2009234 },
+    { url = "https://files.pythonhosted.org/packages/82/3f/76358795aa7a8c6d4f36e2cb828ad1c90ee118e1393a9281664f5aade9d4/pydantic_core-2.46.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:b9fe6fb92520e3fd61f2e49000b6911b188824f089b75973ea06d6267f0b476d", size = 2076516 },
+    { url = "https://files.pythonhosted.org/packages/db/50/26b091836076ce4cb2fac264186936acc069e0595772cfd02a563bc4761a/pydantic_core-2.46.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a39ac25a9a2fa4072efdb429833c4a4c8009a51ff9eea3eeae131713cd27991e", size = 1922874 },
+    { url = "https://files.pythonhosted.org/packages/09/f0/2a8ce3849e299d44e2d2c196b6082643a3235565a735cb51db7a6261f614/pydantic_core-2.46.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4fdc8b93a41521988916eeaa271173fcca7fa0803d62f87675aac8dcec1c8e29", size = 1951772 },
+    { url = "https://files.pythonhosted.org/packages/87/46/ac0dc8bdd9e6048183a14eb127764e7ad9240021c17513074a4711b0e31e/pydantic_core-2.46.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b98134087d9de723658d17a42c7d0da8d6e2ef08015dee7dc93889047315f5e4", size = 2031832 },
+    { url = "https://files.pythonhosted.org/packages/c4/c2/339de5bef7be36301a2231eaa52e62163742c2281f11b5f4892bc79785cd/pydantic_core-2.46.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e652ab17569c94bff5475520f907b7148b8c24036a8ebbe5cf7cf7493d28579a", size = 2208645 },
+    { url = "https://files.pythonhosted.org/packages/7b/a0/9ff22b797724262da14427abaed4dd1d864a139693fc5e7809114376a716/pydantic_core-2.46.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d925f3d9afd05a8c0fb3a1031463a8d59ebe5e2afad297e29c78be19e13b4e62", size = 2265935 },
+    { url = "https://files.pythonhosted.org/packages/c0/a4/eb9409ec0736e50aa70a412f16c204ed149516846912f7e6724d4c73ee53/pydantic_core-2.46.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0fc5be0abd4a407e200d844b404e33639a554e7bd0d448e7b9ae181be4789ac2", size = 2066284 },
+    { url = "https://files.pythonhosted.org/packages/c0/02/7f6156ffc926857f1c37c07d9a388682865a81830ab6a1b637082c25e399/pydantic_core-2.46.5-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:816ff0a6550ffc06c098ccd2e0698600f9aa7da192a79eaa6f9af504a35db869", size = 2105889 },
+    { url = "https://files.pythonhosted.org/packages/92/b1/e781d357ebe09fc929f995700f1b3503e8897f1cece183ecb1300d4d67e9/pydantic_core-2.46.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c7ea57fc63aa7da93a1bd2d644e6577befae10c52c4e36377635eea1056a74f5", size = 2158006 },
+    { url = "https://files.pythonhosted.org/packages/70/0a/644597d84ab400e50609c192120b85c9681c22d3a20461b9060a79be0a7a/pydantic_core-2.46.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:efd62a42486f1bda5d24cb4f63d15a3c7768375fe83d36f9417b4ad7a2fb20b3", size = 2158408 },
+    { url = "https://files.pythonhosted.org/packages/1e/ee/ca3b7b3a4b3769ffe9ce9432a7c9be755de9593a46d3b0d54d0409323e44/pydantic_core-2.46.5-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:2bc9419666990c06d7397831f2126a1ecc3594aaa3ff7de5bf2d066802f4e07b", size = 2309609 },
+    { url = "https://files.pythonhosted.org/packages/ce/52/39fa1f451486019524ca685020390e7ca351832fd874530ba30c8628e6dc/pydantic_core-2.46.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:18a09e1e1011b462f2e32774f25859ef1223d5c2b0546a633cf56654710721e0", size = 2342618 },
+    { url = "https://files.pythonhosted.org/packages/81/5e/468fc630568c61dcef3cd47ad32ffbeed9af643f49208d1ea86ab4f890c4/pydantic_core-2.46.5-cp312-cp312-win32.whl", hash = "sha256:5cb482e9e84c851f4e623fe4acc1ced89168cf1fe18f7089db4548c8f5bbb65b", size = 1939475 },
+    { url = "https://files.pythonhosted.org/packages/cf/c9/4c19f41b84cf6b622a72fbeed7665b25d47a187d68d47d0d430c07f23268/pydantic_core-2.46.5-cp312-cp312-win_amd64.whl", hash = "sha256:5e81740c09e310f5aa5cbd3e434a01c154d4bef93241c7877b39f211d2b78ba8", size = 2043140 },
+    { url = "https://files.pythonhosted.org/packages/af/dd/0c1a050299147c746e5256db16d645ab5efd4f78c59937d581a0524e74a2/pydantic_core-2.46.5-cp312-cp312-win_arm64.whl", hash = "sha256:f7b0ec93a2893de856652154d73b7ba622f26fa97726487dcac373de5f4c6084", size = 1997729 },
+    { url = "https://files.pythonhosted.org/packages/f5/37/5abe39a8372a61d3dc3c1338fc504281c01b32fdb3169cd7187153b56d3e/pydantic_core-2.46.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:b7ca9034437b6022f941f4857459562ee00a560b97e7cce8a0ec5a74fc6766e0", size = 2075885 },
+    { url = "https://files.pythonhosted.org/packages/21/43/6323b1f8b217780454c61304bcd2b38ae4762f50754414124603ccc90bb2/pydantic_core-2.46.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f332f0e72a5a0400141f830744e141bf9f97917878dbe968669e8a7fefea78ff", size = 1922768 },
+    { url = "https://files.pythonhosted.org/packages/0f/a3/c05ca796e1197618a774b01e596aeedfefc2f7d8c01ae3054e910b120e8a/pydantic_core-2.46.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:193375f3548919d3f0b60936ca113ada3e38f264f91b9b8e0508efaad57be931", size = 1951241 },
+    { url = "https://files.pythonhosted.org/packages/68/32/33bc39ac705c52cffc908e8389f9754fdb208aea5c69cceddf4eb3ce99af/pydantic_core-2.46.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:79bdfa52f843137045b2d081cc05c120ba6665d29b7559c2c47690906f39279f", size = 2031975 },
+    { url = "https://files.pythonhosted.org/packages/b0/70/2333e885c0f6a67bc105c5916965dac9b57f2718ee20d81d1a06a4ebdc13/pydantic_core-2.46.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:24922243639cbdac66c75fcb6fd6495a9cb52b213d62f9a0d16f0310b1ff8038", size = 2208542 },
+    { url = "https://files.pythonhosted.org/packages/f7/ea/296debfb4264207bbda5936133892e027c0a58875ad53ebd512fba8ec3a2/pydantic_core-2.46.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c76fe65e607be28c7fd4d56fc3c42b1583aa058ce3408b7ad0fd540171d31f9f", size = 2264692 },
+    { url = "https://files.pythonhosted.org/packages/d3/f2/9e4de77a6271e07a76d2d58b11c091a979c191ed2939bf80067568b369d2/pydantic_core-2.46.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6f7b393a8b3da82f5c1fc0751e6d01ac6c55b93c18226a60bdfba4a724efafd1", size = 2066633 },
+    { url = "https://files.pythonhosted.org/packages/8d/db/f9e9d0c97445987b2084823d5c240de88087338f04fc2cfaa2df186b8049/pydantic_core-2.46.5-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:7ac031912d54f3d83ef3b3eb98dfabc1608802e2202263d25957eeed40b94761", size = 2105235 },
+    { url = "https://files.pythonhosted.org/packages/07/c5/79169b047b3b2c3e99e04bc76372af9637e0bf6db638274fa927df96369e/pydantic_core-2.46.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:837b396ca3d7b74091ca623f6cbd8351bd42d670a79c2683e79fb089f06a2de5", size = 2157367 },
+    { url = "https://files.pythonhosted.org/packages/26/b5/ba6057afb7c291bd449f51b867f95aef2072941c4ce4e5c31d6ffd132d3b/pydantic_core-2.46.5-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:5ee239d575f80b08eca11f6e20f90c4c695de7825c67eefe6091fbf20dda648e", size = 2158420 },
+    { url = "https://files.pythonhosted.org/packages/6e/28/2057abecaafdc22912afa819603a51f0a62d40643b7c4871c51721fea9be/pydantic_core-2.46.5-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:e80675d75ae2cd14372cb65cad5400d9347a3d3f6c13000183f22dfd027283ed", size = 2309588 },
+    { url = "https://files.pythonhosted.org/packages/71/9d/881156dc404e27479c4246128d73538464cab4a239bec61995e227644c30/pydantic_core-2.46.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:9c4b71f10dd532fb7a5cbc8f58707779e64f03a258c2bf8bfbaecfcd9970b519", size = 2341866 },
+    { url = "https://files.pythonhosted.org/packages/5a/38/d66f443a259f84d13babdceae568e572b0ed26da17ca5d0a649ebb110a67/pydantic_core-2.46.5-cp313-cp313-win32.whl", hash = "sha256:97bf8de4d541598c94a59344eeb988a94c08ff76b5723c41f6567ec18c7892ea", size = 1938580 },
+    { url = "https://files.pythonhosted.org/packages/2c/1e/1d5371213f4cc9a7ed70c0bfcc7911de22311ee99a662a56077d7292d2ac/pydantic_core-2.46.5-cp313-cp313-win_amd64.whl", hash = "sha256:15f4a94963c95accac15b7b657bb177d3ad82bb90b0d0526d9a9b85079925db5", size = 2041980 },
+    { url = "https://files.pythonhosted.org/packages/5a/48/4222d90b1c67568bace4dec6dca6271449c66de3595d72b6d098f5fde597/pydantic_core-2.46.5-cp313-cp313-win_arm64.whl", hash = "sha256:d22a945598fb91236b4dd793a6e42e4f3dd7740bb5aace5ebd7d4c08d13bb575", size = 1997213 },
+    { url = "https://files.pythonhosted.org/packages/8e/8a/14596f2a8367da50cf7cbac48169ee5d9c8e11d486a3b527082384630c72/pydantic_core-2.46.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:c1c43ad4339643d70ebb8124e1305a7dab423001eff58bb41a0f731adbc98355", size = 2074081 },
+    { url = "https://files.pythonhosted.org/packages/ae/d5/d8a4eb6d6c7f66b91dd37c576d76e9e60fba900caf5372c17bcf949febc2/pydantic_core-2.46.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1a353f84de772f423b5ffb11d7ae352fbbef0f446f3c0b0af0f8236d7233606e", size = 1920497 },
+    { url = "https://files.pythonhosted.org/packages/8e/26/092079428f86e927e030b2c0ced87df69dbb1c875cdeaa67bf42ea2be746/pydantic_core-2.46.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5086029a57366b8cf81b130a43908738095c270c21a8d7f0e8bdfdb89718e2f3", size = 1952130 },
+    { url = "https://files.pythonhosted.org/packages/08/c3/8ec0e290a9ebaebd64047bf5fda94be835c6b1551b02437e4b76778fbcd7/pydantic_core-2.46.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:46c25dda9d092a06c08db76ffe0a197107904d0dfac653f7d5306bbcd6d6119c", size = 2026371 },
+    { url = "https://files.pythonhosted.org/packages/01/72/4fd20ad520fb8da0157f95b27a7eb05a72790ef08138e7701ac972c342ea/pydantic_core-2.46.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:37ea7b83c935e5b0d68c9449b82651accf78a10828b2c02b2f2d9e9496446c21", size = 2202822 },
+    { url = "https://files.pythonhosted.org/packages/31/b0/d16e0771206b29314f0d52198b720be21e8a99ab2bf11e3bc0d7c9cebdff/pydantic_core-2.46.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e64e88d5585bea9ce95861079de72006c7fa6d3df4e3a3b65ba31eb979c15c9f", size = 2262756 },
+    { url = "https://files.pythonhosted.org/packages/2c/9b/59634b7ac631c63b2a37760eb6943af3e29573d6b59a4abc5e7f019d4cee/pydantic_core-2.46.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:54d510bac3ee52247af28ed4bb18a1e799f040ac60fd2bf5ccd4c92f1fbe786f", size = 2068352 },
+    { url = "https://files.pythonhosted.org/packages/08/7c/570abb1ad2155348dc754ea91be22e5aaa18eb6d69a6068f7c6f2679a6ed/pydantic_core-2.46.5-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:a2a5e1d0ff29adddc9f6d6821a66302e4493f8ca898b715b6b1182c2c201ea0a", size = 2104777 },
+    { url = "https://files.pythonhosted.org/packages/8e/25/5bf74adc65a1ac5b7be3f6cb0bcb5433615c1598a801c19d830d84c98ded/pydantic_core-2.46.5-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:03b9666e41e35d8909852ba191a0607520f81b74eaf12ccf8737005dbb313821", size = 2156312 },
+    { url = "https://files.pythonhosted.org/packages/90/6a/2ef38830675e050121040618135564ed56b860b45433b02d9b4ebece46f3/pydantic_core-2.46.5-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:a91c17edf6eea2402cb5457b4c89e99bc5ed1004aa34c4adf1d4258c1a5c22c2", size = 2150067 },
+    { url = "https://files.pythonhosted.org/packages/90/ef/a7dbb03a14a64c2a4621f989c615ed9a892535a6cad938fc27079f919d80/pydantic_core-2.46.5-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b49924c73a235e969511bf2aabdff3beebf9820931f646c80274d5d780010c47", size = 2304516 },
+    { url = "https://files.pythonhosted.org/packages/68/f8/6bb4c4b80e8a6fde1904c64a51c62a1d04fcdfa3ea521a66b2ddefa1d885/pydantic_core-2.46.5-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:2cbd9a5eff05e51c447c34dfa4632145b26b09120cf04bd0c871e44c1a5e1c9a", size = 2335223 },
+    { url = "https://files.pythonhosted.org/packages/2a/80/f46b8c681195190b2c1f1c7c0a81abce60663e987613e09ef64d433dd96b/pydantic_core-2.46.5-cp314-cp314-win32.whl", hash = "sha256:2d5d76654becf5efd62c9e51c3756c67b49498b0c9a40884934c40807adbd074", size = 1934827 },
+    { url = "https://files.pythonhosted.org/packages/f7/3c/60674207246bc0a4009d2391b7c7251c7159f279c8d2ab8aae8ef46f3dee/pydantic_core-2.46.5-cp314-cp314-win_amd64.whl", hash = "sha256:fa10ef4112775900e7a0661068635eb67b2ab824fbde764de6e0e21982a93db0", size = 2042648 },
+    { url = "https://files.pythonhosted.org/packages/69/0c/117c562c7c1babdf44576b72a5e496906506c93690387ecfbca7c729ae2e/pydantic_core-2.46.5-cp314-cp314-win_arm64.whl", hash = "sha256:045ab3b6d308439e32b81cc173bba5b9018bc6ed896afd0c65b3b009b1699af5", size = 1989652 },
+    { url = "https://files.pythonhosted.org/packages/e8/66/9336ae58f9eb68c41d121894e52c4c89eccb07eb8f602a04ee9c3f37736a/pydantic_core-2.46.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8816f3d218beb4b787de5c9759c259b8fa61f9dec42dc7811f320a33771778b7", size = 2065829 },
+    { url = "https://files.pythonhosted.org/packages/c5/02/bc19b47a96c2d3109760711acf22369e56bd7e405ca52f7ade164d2ead57/pydantic_core-2.46.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:bce57638e08ac148e5778cce7feb968307a727d66f8e2274a543d0cf0c9ad6a3", size = 1905716 },
+    { url = "https://files.pythonhosted.org/packages/52/a4/70b47c0509923dd98ccfed04fb3e32ea3849c82a0ff2205bb41009b43c00/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:976e1128455aa595ea04c79ccfedff1aaeab96ee013fcc916bed120c4f0ad94f", size = 1934216 },
+    { url = "https://files.pythonhosted.org/packages/52/ab/aa03b65f7bb198585edf806b906c3223ecf1795543e39e23aec4cce27ad2/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e7b891faeedeafba41b2983e5001a81b6a915b69544c7e7570d1989ce1c36ac7", size = 2010635 },
+    { url = "https://files.pythonhosted.org/packages/3c/8b/0da06343f30b84ec549aafd309c6456223d5dc8bd36af504c573faad561d/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5f194189415698233dd1114a093a9b56e61e2c57e11b469be3b0506f46f0771c", size = 2209369 },
+    { url = "https://files.pythonhosted.org/packages/d6/5b/844c4defaa34a3df66eb9257087d121d70c201298b96abdf9f492fc2f1bf/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:82a36973cf8a2ef5406f4fe2edbf8ed0c99629535d959e0b100c76a32535a111", size = 2253238 },
+    { url = "https://files.pythonhosted.org/packages/f4/64/a4e536cb16d7f61a7fd3120b46c577fc7fa7325992f69c4f52bc786d77d8/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cdbb78909f52b981d3b2d56b97328d71eb0b974c36bd77c920123a7ebb192829", size = 2065740 },
+    { url = "https://files.pythonhosted.org/packages/5f/75/aaa38c6bc2d085f6605b34eabdc6a8a4e0b2e61fc9c8e6e52b28e97b3125/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:52e24eacdb536cade636aa90fb851835222becff8484b7001fdc78cb0290f2aa", size = 2087425 },
+    { url = "https://files.pythonhosted.org/packages/55/ae/fcab4cfc39aba3689e1d20c8b5250ad280957022c09af2ed9cd585602a5e/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:37ae34309d7bd8c0d61ab839668058f2a7962ea1fc51d105d2db228fe0618034", size = 2139306 },
+    { url = "https://files.pythonhosted.org/packages/2d/f4/f1d03a4bc9d9acbc62f4d742b8a319af52f71885079868b2ff8e48a651ee/pydantic_core-2.46.5-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:0cdbada856a1c69a7624a64d3d9aefe79300bd6ef827b43a4f265010b9b55184", size = 2144589 },
+    { url = "https://files.pythonhosted.org/packages/83/f3/7a53bb1356de514a4cd295f25b6ac39237895620c0462d2592b76c16e114/pydantic_core-2.46.5-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:545f26c504b27c3758439a5e6d9349931f0a04f855668d5fe323c89e82300a38", size = 2288882 },
+    { url = "https://files.pythonhosted.org/packages/cd/94/5a81583660c175c59d49ffb09f4b3a44debeaf86a19fca664ae1cdd9ee32/pydantic_core-2.46.5-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:ff218293c9c806138dca139765e3b067621be52bcd93cdc14c7711be7ddc90a9", size = 2335210 },
+    { url = "https://files.pythonhosted.org/packages/5a/9f/5d685c2693b972d1a59c998586e8823712b66603aeff47ee60a4bdaafd37/pydantic_core-2.46.5-cp314-cp314t-win32.whl", hash = "sha256:97cf3eb53a8cccacf9d46686a0926186c9bfb5574f2ed66d3639d5fe117cd3a9", size = 1921180 },
+    { url = "https://files.pythonhosted.org/packages/70/12/5c94ee16d65a37a15f9e869f5e6256df111154491173801a4c5e800ab548/pydantic_core-2.46.5-cp314-cp314t-win_amd64.whl", hash = "sha256:d2f9fc07a8042a8f95925b35c4f04f469707c981fc33245b6ca187cf5d2dd290", size = 2020515 },
+    { url = "https://files.pythonhosted.org/packages/63/19/67830dda664e6bdf9285ee2e40f355d0d7d6b92aa0c42e8d217bb8d33d36/pydantic_core-2.46.5-cp314-cp314t-win_arm64.whl", hash = "sha256:acf8a67ba51f4ca9ddbd0e6b3000a65ac51ab734661778b3e7ba64d99a710f2f", size = 1989276 },
+    { url = "https://files.pythonhosted.org/packages/20/21/22102e9950b3049526d20e811b95396508377d87651edd2b80d2b3d28659/pydantic_core-2.46.5-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:ab4b66edffb32d9e951efb3814bd104b8367a7501b81b955cacb5726d897389f", size = 2071333 },
+    { url = "https://files.pythonhosted.org/packages/d8/18/87aefa427d191e6d3ab1447f1efc1cdcac86af1069239b133e8a0fd7f7c9/pydantic_core-2.46.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:337639ba62a11acde6ef3aeb08c8ea755f8ef1fe5e513356c0f36a2b0d7568b0", size = 1912713 },
+    { url = "https://files.pythonhosted.org/packages/1f/93/fd89e9ad49b1805ca94d24ce1088b7d305f05c35ffafcedb9819d03588a0/pydantic_core-2.46.5-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:413a717a410d0c817ef5b786a059415550b3794e1d0c2abffd9efb93a3d9f7b4", size = 2090926 },
+    { url = "https://files.pythonhosted.org/packages/6f/45/8e59dab6acf8d35f02f0a958980074f31038968bdb2c983fcae9d1efee03/pydantic_core-2.46.5-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1e449def1945a462c464331254e5a44fca7c3b4f9aedf59ec2f50f8066dd8e25", size = 2131303 },
+    { url = "https://files.pythonhosted.org/packages/d5/a5/e1d4dc5180dd887a9522efc1f8716b8692b7606b1d3273d7862eaf66be44/pydantic_core-2.46.5-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:a445486499897b88a7d6c310c88ed64dd37b1b59bfd7ae9107490bbb362f47d6", size = 2145128 },
+    { url = "https://files.pythonhosted.org/packages/c2/d7/ad493864a7fb21c0c4df98f965e2db430cb25a9d7369b5778d5016c09fd9/pydantic_core-2.46.5-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:2d330aaba8621b1edcec8ae2c4050f63b84ccf6d98723a8f212e9684713abf0e", size = 2294560 },
+    { url = "https://files.pythonhosted.org/packages/02/8e/b41c84c913f29973a268e6c2b5bbf13c95adb9956c126d10da11ba3b2bef/pydantic_core-2.46.5-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:b6acfb46a814762367fb7ba0828b0a17d441b92ce249a0e007474c9072662dda", size = 2317531 },
+    { url = "https://files.pythonhosted.org/packages/db/1d/068464f23075f66a8f1b806935e9cd9363ee446636ea70d2c22ee8659dbf/pydantic_core-2.46.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d0a24b40877af2de4950252be9d21eaf7fb07660f3c2cae1f56c6b599ada5266", size = 2140686 },
 ]
 
 [[package]]
@@ -633,6 +973,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293 },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274 },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]
@@ -684,6 +1041,40 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bc/57/e84d88dfe0aec03b7a2d4327012c1627ab5f03652216c63d49846d7a6c58/python-dotenv-1.0.1.tar.gz", hash = "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca", size = 39115 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/3e/b68c118422ec867fa7ab88444e1274aa40681c606d59ac27de5a5588f082/python_dotenv-1.0.1-py3-none-any.whl", hash = "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a", size = 19863 },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042 },
+]
+
+[[package]]
+name = "pywin32"
+version = "312"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/1b/9cfdeac80ee45bebbbcb31f1b7b99a0d81a1c72de48d837be984e0e88b1d/pywin32-312-cp310-cp310-win32.whl", hash = "sha256:772235332b5d1024c696f11cea1ae4be7930f0a8b894bb43db14e3f435f1ff7e", size = 6361387 },
+    { url = "https://files.pythonhosted.org/packages/33/b1/7afc96d041d982c27bc2df6f853d43f01fd273e3d39d04be3647ddeb533d/pywin32-312-cp310-cp310-win_amd64.whl", hash = "sha256:5dbc35d2b5320dc07f25fa31269cfb767471002b17de5eb067d03da68c7cb2db", size = 6926780 },
+    { url = "https://files.pythonhosted.org/packages/ce/3a/4140da9ad54108e517f4a16b2d83da3033e08662144623e1239587cb7db6/pywin32-312-cp310-cp310-win_arm64.whl", hash = "sha256:3020656e34f1cf7faeb7bccd2b84653a607c6ff0c55ada85e6487d61716deabd", size = 4307203 },
+    { url = "https://files.pythonhosted.org/packages/1f/f5/10a6e845a00fc5e7afd0a988b744f403d4d57162a28d160a093c4d9322f0/pywin32-312-cp311-cp311-win32.whl", hash = "sha256:17948aeadbdb091f0ced6ef0841620794e68327b94ee415571c1203594b7215c", size = 6362659 },
+    { url = "https://files.pythonhosted.org/packages/35/c4/dcd2d62b5944b6d5db53413a5899016ccd57ffcb7278f3f81655d25d2027/pywin32-312-cp311-cp311-win_amd64.whl", hash = "sha256:d11417d84412f859b722fad0841b3614459ed0047f7542d8362e77884f6b6e8a", size = 6928825 },
+    { url = "https://files.pythonhosted.org/packages/b7/56/3cbb433fe4501cdba2eb9040f56a4e1a8243faa4186b25295564d1a7a79d/pywin32-312-cp311-cp311-win_arm64.whl", hash = "sha256:b2200a054ca6d6625c4842fc56a4976a4b47f96b73dbe5538c3f813a80359f47", size = 6721875 },
+    { url = "https://files.pythonhosted.org/packages/83/ff/32aa7d2ed0ab12b323aaa64f9b75e6ad4f8fd09f9ccfc28c79414d46838d/pywin32-312-cp312-cp312-win32.whl", hash = "sha256:dab4f65ac9c4e48400a2a0530c46c3c579cd5905ecd11b80692373915269208b", size = 6371877 },
+    { url = "https://files.pythonhosted.org/packages/03/d9/77040d3b43df3f3be32ea289433d660d2727f5ba327bc73be835127d9d60/pywin32-312-cp312-cp312-win_amd64.whl", hash = "sha256:b457f6d628a47e8a7346ce22acb7e1a46a4a78b52e1d17e1af56871bd19a93bc", size = 6914841 },
+    { url = "https://files.pythonhosted.org/packages/e3/cc/7b1ec671775756020a0ee7f4feeaf3c568f0ab86bd3900088cf986937a92/pywin32-312-cp312-cp312-win_arm64.whl", hash = "sha256:6017c58e12f6809fbb0555b75df144c2922a9ffd18e4b9b5afa863b6c1a9d950", size = 6727901 },
+    { url = "https://files.pythonhosted.org/packages/2d/41/12fbfd7f36ed2146d8bc9de96c2741296bf0d490b98508496cff322e274c/pywin32-312-cp313-cp313-win32.whl", hash = "sha256:7a27df850933d16a8eabfbaeb73d52b273e2da667f80d70b01a89d1f6828d02c", size = 6370184 },
+    { url = "https://files.pythonhosted.org/packages/ba/db/36a78e3403099d31d9746d13fdcde5accc43c1155f375a34d15983a479a7/pywin32-312-cp313-cp313-win_amd64.whl", hash = "sha256:c53e878d15a1c44788082bfe712a905433473aa38f86375b7cf8b45e3acbaaf9", size = 6914298 },
+    { url = "https://files.pythonhosted.org/packages/84/37/c1697194092b76de9ed47ca124323f02c57ffc8a45c06f88a3d5acaf01eb/pywin32-312-cp313-cp313-win_arm64.whl", hash = "sha256:59aba5d5940842075343a5ddc6b11f1cdf0d1567fe745290359dfbcc7c2eb831", size = 6727640 },
+    { url = "https://files.pythonhosted.org/packages/fc/2b/1f3cded5822fd49c02f40544cbb5f58c7cfd6b1694869fd476cb6170ee97/pywin32-312-cp314-cp314-win32.whl", hash = "sha256:a77a90fbb6881238d2ca9c6fd797b25817f3768fe78d214a90137ff055a75f5b", size = 6468928 },
+    { url = "https://files.pythonhosted.org/packages/21/82/3bf86d2e2808902013132e1ce905a7da0da53790f3836c64bf44d55e24f3/pywin32-312-cp314-cp314-win_amd64.whl", hash = "sha256:a4dd3a848290ef724347b19f301045831d8e802fa4464f491b98b1e0a081432e", size = 7024157 },
+    { url = "https://files.pythonhosted.org/packages/a4/0e/73f6d6800b4f27655abd9e9f6aaeaefcddb2b946e4674efa2bab184a7f7b/pywin32-312-cp314-cp314-win_arm64.whl", hash = "sha256:9fce94568364e0155e6dfb781ac5d95903be8baf28670632beab1b523f300daa", size = 6839598 },
+    { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159 },
+    { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293 },
+    { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337 },
 ]
 
 [[package]]
@@ -945,37 +1336,66 @@ wheels = [
 ]
 
 [[package]]
-name = "sniffio"
-version = "1.3.1"
+name = "sse-starlette"
+version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372 }
+resolution-markers = [
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "(python_full_version < '3.14' and sys_platform != 'emscripten') or (python_full_version < '3.12' and sys_platform == 'emscripten')",
+]
+dependencies = [
+    { name = "anyio", marker = "python_full_version < '3.14'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/3c/fa6517610dc641262b77cc7bf994ecd17465812c1b0585fe33e11be758ab/sse_starlette-3.0.3.tar.gz", hash = "sha256:88cfb08747e16200ea990c8ca876b03910a23b547ab3bd764c0d8eb81019b971", size = 21943 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
+    { url = "https://files.pythonhosted.org/packages/23/a0/984525d19ca5c8a6c33911a0c164b11490dd0f90ff7fd689f704f84e9a11/sse_starlette-3.0.3-py3-none-any.whl", hash = "sha256:af5bf5a6f3933df1d9c7f8539633dc8444ca6a97ab2e2a7cd3b6e431ac03a431", size = 11765 },
 ]
 
 [[package]]
 name = "sse-starlette"
-version = "2.2.1"
+version = "3.4.11"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "starlette" },
+resolution-markers = [
+    "python_full_version >= '3.14'",
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/71/a4/80d2a11af59fe75b48230846989e93979c892d3a20016b42bb44edb9e398/sse_starlette-2.2.1.tar.gz", hash = "sha256:54470d5f19274aeed6b2d473430b08b4b379ea851d953b11d7f1c4a2c118b419", size = 17376 }
+dependencies = [
+    { name = "anyio", marker = "python_full_version >= '3.14'" },
+    { name = "starlette", version = "1.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2b/54/6767bb789b2f2fed6e0f953df949cd39dc263a384c1b65a95232598621d6/sse_starlette-3.4.11.tar.gz", hash = "sha256:1bae716c02f3e6f294be41ff333220692dae7c3cbab077c900f159676719dade", size = 34972 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/e0/5b8bd393f27f4a62461c5cf2479c75a2cc2ffa330976f9f00f5f6e4f50eb/sse_starlette-2.2.1-py3-none-any.whl", hash = "sha256:6410a3d3ba0c89e7675d4c273a301d64649c03a5ef1ca101f10b47f895fd0e99", size = 10120 },
+    { url = "https://files.pythonhosted.org/packages/98/6a/2ba3ed4a69babf3afdddf7d8314a48d87562c0a442206bbc2a1b50d5efc0/sse_starlette-3.4.11-py3-none-any.whl", hash = "sha256:c7b2244bdff016fe7f64e10075e89a3e6bbf899649cc89b0fe884b5545042453", size = 17122 },
 ]
 
 [[package]]
 name = "starlette"
 version = "0.45.3"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "(python_full_version < '3.14' and sys_platform != 'emscripten') or (python_full_version < '3.12' and sys_platform == 'emscripten')",
+]
 dependencies = [
-    { name = "anyio" },
+    { name = "anyio", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ff/fb/2984a686808b89a6781526129a4b51266f678b2d2b97ab2d325e56116df8/starlette-0.45.3.tar.gz", hash = "sha256:2cbcba2a75806f8a41c722141486f37c28e30a0921c5f6fe4346cb0dcee1302f", size = 2574076 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/61/f2b52e107b1fc8944b33ef56bf6ac4ebbe16d91b94d2b87ce013bf63fb84/starlette-0.45.3-py3-none-any.whl", hash = "sha256:dfb6d332576f136ec740296c7e8bb8c8a7125044e7c6da30744718880cdd059d", size = 71507 },
+]
+
+[[package]]
+name = "starlette"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14'",
+]
+dependencies = [
+    { name = "anyio", marker = "python_full_version >= '3.14'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/b4/205b0d5241d934e8add0c38aa924c4f9fb7330834ff11e5444db964ec3f9/starlette-1.6.0.tar.gz", hash = "sha256:d4e3ac5e546444960c710297a3c9fc3f7ebae1b7e963f3d36173b49da535be9b", size = 2716969 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/cb/6a6a47d5b464bd08695d254f3da6e7986cc70c9fa5d778eda57538edfe56/starlette-1.6.0-py3-none-any.whl", hash = "sha256:a86dd39d14bb45f85a3d18525215a9ef0cfd1f192ac793220e72598c90335f0c", size = 75969 },
 ]
 
 [[package]]
@@ -1018,27 +1438,48 @@ wheels = [
 ]
 
 [[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660 },
+]
+
+[[package]]
 name = "typer"
-version = "0.15.1"
+version = "0.27.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
+    { name = "annotated-doc" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "rich" },
     { name = "shellingham" },
-    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cb/ce/dca7b219718afd37a0068f4f2530a727c2b74a8b6e8e0c0080a4c0de4fcd/typer-0.15.1.tar.gz", hash = "sha256:a0588c0a7fa68a1978a069818657778f86abe6ff5ea6abf472f940a08bfe4f0a", size = 99789 }
+sdist = { url = "https://files.pythonhosted.org/packages/16/f7/57713ba479fd405eb76de31404b2c744c289e336b2d999511ebf51e496f7/typer-0.27.2.tar.gz", hash = "sha256:269b7eb9d3c202ca84b4bc9618cb04ebb43d3d4d1e567e4c768607232c05f945", size = 204045 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/cc/0a838ba5ca64dc832aa43f727bd586309846b0ffb2ce52422543e6075e8a/typer-0.15.1-py3-none-any.whl", hash = "sha256:7994fb7b8155b64d3402518560648446072864beefd44aa2dc36972a5972e847", size = 44908 },
+    { url = "https://files.pythonhosted.org/packages/dc/bf/205d0004930ede8f542fb58f601526fccf4ae7626075ca1e6c4de5d3d652/typer-0.27.2-py3-none-any.whl", hash = "sha256:b3a5fc4342d5fc8fda8fc3010b1cf117e9249aab7fae800c2eff62fd3842d97d", size = 123130 },
 ]
 
 [[package]]
 name = "typing-extensions"
-version = "4.12.2"
+version = "4.16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8", size = 85321 }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d", size = 37438 },
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571 },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/26/b09b8010994eccc3c09092e6b34058f36a460eea2d4c3e8b910c695975a0/typing_inspection-0.4.4.tar.gz", hash = "sha256:547274fa6b0a561ccf549cc9524b999a578e737d015d8709d021f9d0d13bea47", size = 76928 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/81/4add07e5172b7ac40d8ed5ff580409a7801a4fe26d529bdd915401dabfbe/typing_inspection-0.4.4-py3-none-any.whl", hash = "sha256:65b8397ba37ccbce054456aaccddfc91e6e3083c92824df348d96ca832f3f147", size = 14750 },
 ]
 
 [[package]]
@@ -1056,7 +1497,8 @@ version = "0.34.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
-    { name = "h11" },
+    { name = "h11", version = "0.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'" },
+    { name = "h11", version = "0.16.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4b/4d/938bd85e5bf2edeec766267a5015ad969730bb91e31b44021dfe8b22df6c/uvicorn-0.34.0.tar.gz", hash = "sha256:404051050cd7e905de2c9a7e61790943440b3416f49cb409f965d9dcd0fa73e9", size = 76568 }


### PR DESCRIPTION
Closes #65.

Port both server modes to `mcp>=2,<3` so 2026-era clients can talk without an `initialize` handshake or `Mcp-Session-Id`.

**Fixes**
- Fresh `uvx mcp-openapi-proxy` no longer crashes on mcp 2.x (0.3.4 only *pinned away* from 2.x; this *runs* it).
- Native stateless Streamable HTTP (`MCP_TRANSPORT=streamable-http`) — no sticky sessions.
- `tools/list` / `tools/call` work on a fresh request (proven live: apisguru, gpt-terminal-plus).
- `MCP_SERVER_NAME` so instances advertise `gpt-terminal-plus` / `flyio` / … instead of `OpenApiProxy-LowLevel`.
- Dual-stack stdio still answers legacy `initialize` (Cursor, etc.).

**Breaking**
- Requires mcp 2.x. 0.3.6 remains the last `mcp<2` line.
- See `docs/MIGRATION-0.4.md`.

Live host already runs this checkout behind `https://mcp.teamstinky.duckdns.org`.